### PR TITLE
Made kerrareg available in a namespace scoped mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <img src="img/kerrareg.png" width="400" />
 </p>
 
-A Kubernetes-native, self-hosted module registry that implements the [Module Registry Protocol](https://opentofu.org/docs/internals/module-registry-protocol/). Kerrareg gives organizations complete control over module distribution, versioning, and storage — without relying on the public registry.
+A Kubernetes-native, self-hosted OpenTofu/Terraform module registry that implements the [Module Registry Protocol](https://opentofu.org/docs/internals/module-registry-protocol/). Kerrareg gives organizations complete control over module distribution, versioning, and storage — without relying on the public registry.
 
 Compatible with **OpenTofu** (all versions) and **Terraform** (v1.2+).
 
@@ -462,6 +462,7 @@ These values apply to `version`, `module`, and `depot` independently:
 | `serviceAccount.create` | `true` | Create service accounts |
 | `serviceAccount.annotations` | `{}` | Annotations (use for IRSA/Workload Identity) |
 | `rbac.create` | `true` | Create RBAC roles and bindings |
+| `rbac.scopeToNamespace` | `false` | Use namespace-scoped Role/RoleBinding instead of ClusterRole/ClusterRoleBinding |
 
 #### Storage
 
@@ -733,12 +734,23 @@ kubectl create rolebinding test-user-reader -n kerrareg-system \
   --serviceaccount=kerrareg-system:test-user
 ```
 
-Generate a short-lived token and set it as the registry credential:
+Generate a short-lived token and write it to `~/.terraform.d/credentials.tfrc.json`, using the `host:port` of your Kerrareg server as the credential key:
 
 ```bash
-export TF_TOKEN_KERRAREG_DEFDEV_IO=$(kubectl create token test-user -n kerrareg-system)
-tofu init -backend=false
+TOKEN=$(kubectl create token test-user -n kerrareg-system) && \
+PORT=$(docker ps --filter "name=kindccm" --format '{{.Ports}}' | sed -n 's/.*:\([0-9]*\)->443.*/\1/p') && \
+mkdir -p ~/.terraform.d && cat > ~/.terraform.d/credentials.tfrc.json <<EOF
+{
+  "credentials": {
+    "kerrareg.defdev.io:${PORT}": {
+      "token": "${TOKEN}"
+    }
+  }
+}
+EOF
 ```
+> [!NOTE]
+> Because `cloud-provider-kind` assigns a non-standard port (not `443`), you must use a `credentials.tfrc.json` file for authentication. The `TF_TOKEN_` environment variable approach does not support hostnames with port numbers.
 
 OpenTofu sends the bearer token to Kerrareg, which forwards it to the Kubernetes API for authentication and RBAC authorization. This is the same flow used in production — no separate user database or API keys required.
 
@@ -778,6 +790,26 @@ sudo sed -i '' '/kerrareg.defdev.io/d' /etc/hosts
 ```
 
 ## Configuration
+
+### Namespace-Scoped Mode
+
+By default, Kerrareg controllers use `ClusterRole`/`ClusterRoleBinding` and watch resources across all namespaces. To restrict controllers to a single namespace, enable namespace-scoped mode:
+
+```yaml
+rbac:
+  scopeToNamespace: true
+
+global:
+  namespace: my-kerrareg-namespace
+```
+
+When `rbac.scopeToNamespace` is `true`:
+
+- RBAC resources are created as `Role`/`RoleBinding` scoped to `global.namespace`
+- Each controller only watches and reconciles resources in that namespace
+- The `WATCH_NAMESPACE` environment variable is automatically set on controller pods
+
+This is useful in multi-tenant clusters or environments where cluster-wide permissions are not available.
 
 ### GitHub Authentication
 
@@ -943,11 +975,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::<ACCOUNT_ID>:role/kerrareg-github-actions-role
+          aws-region: us-west-2
+
       - name: Setup kubeconfig
-        run: |
-          mkdir -p ~/.kube
-          echo "${{ secrets.KERRAREG_KUBECONFIG }}" | base64 -d > ~/.kube/config
-          chmod 600 ~/.kube/config
+        run: aws eks update-kubeconfig --name my-cluster --region us-west-2
 
       - name: Publish module version
         run: |

--- a/chart/kerrareg/templates/depot-deployment.yaml
+++ b/chart/kerrareg/templates/depot-deployment.yaml
@@ -27,6 +27,11 @@ spec:
       - name: depot-controller
         image: "{{ .Values.depot.image.repository }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        {{- if .Values.rbac.scopeToNamespace }}
+        env:
+        - name: WATCH_NAMESPACE
+          value: {{ .Values.global.namespace }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/chart/kerrareg/templates/depot-rbac.yaml
+++ b/chart/kerrareg/templates/depot-rbac.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.depot.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
 metadata:
   name: depot-controller
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - kerrareg.io
@@ -51,12 +54,15 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.scopeToNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 metadata:
   name: depot-controller-role-binding
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
   name: depot-controller
 subjects:
 - kind: ServiceAccount

--- a/chart/kerrareg/templates/module-deployment.yaml
+++ b/chart/kerrareg/templates/module-deployment.yaml
@@ -27,6 +27,11 @@ spec:
       - name: deployment-controller
         image: "{{ .Values.module.image.repository }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        {{- if .Values.rbac.scopeToNamespace }}
+        env:
+        - name: WATCH_NAMESPACE
+          value: {{ .Values.global.namespace }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/chart/kerrareg/templates/module-rbac.yaml
+++ b/chart/kerrareg/templates/module-rbac.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.module.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
 metadata:
   name: module-controller-role
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - kerrareg.io
@@ -43,12 +46,15 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.scopeToNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 metadata:
   name: module-controller-role-binding
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
   name: module-controller-role
 subjects:
 - kind: ServiceAccount

--- a/chart/kerrareg/templates/server-rbac.yaml
+++ b/chart/kerrareg/templates/server-rbac.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.server.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
 metadata:
   name: server-role
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - kerrareg.io
@@ -21,12 +24,15 @@ rules:
   - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.scopeToNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 metadata:
   name: server-role-binding
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
   name: server-role
 subjects:
 - kind: ServiceAccount

--- a/chart/kerrareg/templates/version-deployment.yaml
+++ b/chart/kerrareg/templates/version-deployment.yaml
@@ -43,6 +43,11 @@ spec:
       - name: version-controller
         image: "{{ .Values.version.image.repository }}:{{ .Values.global.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+        {{- if .Values.rbac.scopeToNamespace }}
+        env:
+        - name: WATCH_NAMESPACE
+          value: {{ .Values.global.namespace }}
+        {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
           {{- if not .Values.storage.filesystem.enabled }}

--- a/chart/kerrareg/templates/version-rbac.yaml
+++ b/chart/kerrareg/templates/version-rbac.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.version.enabled .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
 metadata:
   name: version-controller-role
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 rules:
 - apiGroups:
   - kerrareg.io
@@ -56,12 +59,15 @@ rules:
   - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: {{ if .Values.rbac.scopeToNamespace }}RoleBinding{{ else }}ClusterRoleBinding{{ end }}
 metadata:
   name: version-controller-role-binding
+  {{- if .Values.rbac.scopeToNamespace }}
+  namespace: {{ .Values.global.namespace }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ if .Values.rbac.scopeToNamespace }}Role{{ else }}ClusterRole{{ end }}
   name: version-controller-role
 subjects:
 - kind: ServiceAccount

--- a/chart/kerrareg/values.yaml
+++ b/chart/kerrareg/values.yaml
@@ -116,6 +116,9 @@ serviceAccount:
 rbac:
   # Create RBAC roles and role bindings
   create: true
+  # When true, use namespace-scoped Role/RoleBinding instead of ClusterRole/ClusterRoleBinding.
+  # Controllers will only watch resources in global.namespace.
+  scopeToNamespace: false
 
 ## Storage configuration
 storage:

--- a/services/version/cmd/main.go
+++ b/services/version/cmd/main.go
@@ -30,6 +30,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -181,25 +182,25 @@ func main() {
 		})
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	mgrOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "63f43f47.kerrareg.io",
-		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
-		// when the Manager ends. This requires the binary to immediately end when the
-		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
-		// LeaseDuration time first.
-		//
-		// In the default scaffold provided, the program ends immediately after
-		// the manager stops, so would be fine to enable this option. However,
-		// if you are doing or is intended to do any operation such as perform cleanups
-		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	if watchNS := os.Getenv("WATCH_NAMESPACE"); watchNS != "" {
+		setupLog.Info("restricting controller to namespace", "namespace", watchNS)
+		mgrOptions.Cache = cache.Options{
+			DefaultNamespaces: map[string]cache.Config{
+				watchNS: {},
+			},
+		}
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOptions)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
This pull request introduces support for namespace-scoped operation in Kerrareg, allowing controllers and RBAC resources to be restricted to a single namespace instead of cluster-wide. This makes Kerrareg more suitable for multi-tenant clusters and environments with limited permissions. The changes include updates to Helm charts, controller logic, and documentation to enable and explain this new mode. Additionally, there are improvements to authentication instructions and CI/CD setup.

**Namespace-Scoped Operation Support:**

* Added a new `rbac.scopeToNamespace` value in `values.yaml` and documented it in `README.md`. When enabled, all RBAC resources (`Role`, `RoleBinding`) and controllers are restricted to the specified namespace (`global.namespace`). [[1]](diffhunk://#diff-9ef6d5890bfc1dd6982d59da7ea11fabed2591463d1863fd99f82ca9de0cea38R119-R121) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R465) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R794-R813)
* Updated all Helm RBAC templates (`server-rbac.yaml`, `module-rbac.yaml`, `depot-rbac.yaml`, `version-rbac.yaml`) to conditionally create namespace-scoped `Role`/`RoleBinding` resources and set their namespace when `rbac.scopeToNamespace` is true. [[1]](diffhunk://#diff-2b1bd74f32f08e65979eeb92940e98fa732c521ac66fdba9831f89986754dc1bL3-R8) [[2]](diffhunk://#diff-2b1bd74f32f08e65979eeb92940e98fa732c521ac66fdba9831f89986754dc1bL24-R35) [[3]](diffhunk://#diff-d10c322515a0ea2bb3838c2bd8194e99a9d02a57099608e0fcc64ba58a0783d7L3-R8) [[4]](diffhunk://#diff-d10c322515a0ea2bb3838c2bd8194e99a9d02a57099608e0fcc64ba58a0783d7L46-R57) [[5]](diffhunk://#diff-b511bdf2eeed466a1e78c35b670e326dbaaf10f954fe3e1c66e8c497cf384fb4L3-R8) [[6]](diffhunk://#diff-b511bdf2eeed466a1e78c35b670e326dbaaf10f954fe3e1c66e8c497cf384fb4L54-R65) [[7]](diffhunk://#diff-f1cd81c1112bb18fb87779e4ca5022ce24f261f59ea1e6009dce9cd17dcd8c7eL3-R8) [[8]](diffhunk://#diff-f1cd81c1112bb18fb87779e4ca5022ce24f261f59ea1e6009dce9cd17dcd8c7eL59-R70)
* Updated all controller deployment templates to set the `WATCH_NAMESPACE` environment variable when namespace-scoped mode is enabled, ensuring controllers only watch their assigned namespace. [[1]](diffhunk://#diff-be5aec6a24a004de3be5b75e822056106848c79fd98d704debfd806f759b5842R30-R34) [[2]](diffhunk://#diff-9ef8a653b992665461f1c95b74dbdd6bd8acde39149a15341679e42811b63cffR30-R34) [[3]](diffhunk://#diff-cfe5431af3e563af2cc467dbd6042ef5161de5f9a9e44431ac0dc1cd0f7bf285R46-R50)

**Controller Logic:**

* Modified the `version` controller (`services/version/cmd/main.go`) to read the `WATCH_NAMESPACE` environment variable and configure the controller-runtime cache to watch only that namespace. [[1]](diffhunk://#diff-36e1020ddd8038cb3e49aef218b7e5f08a4a3adf36fd3de74173abf9dc0c8c00R33) [[2]](diffhunk://#diff-36e1020ddd8038cb3e49aef218b7e5f08a4a3adf36fd3de74173abf9dc0c8c00L184-R203)

**Documentation and Usability Improvements:**

* Expanded documentation in `README.md` to explain the new namespace-scoped mode, including configuration examples and its benefits for multi-tenant clusters.
* Clarified authentication steps for local development, explaining the need for `credentials.tfrc.json` when using non-standard ports and why the `TF_TOKEN_` environment variable is insufficient in those cases.
* Updated the CI/CD example to use AWS IAM roles and `aws eks update-kubeconfig` instead of a static kubeconfig secret, improving security and maintainability.

**Other:**

* Minor clarification in the project description to explicitly mention both OpenTofu and Terraform compatibility.