### PR TITLE
Provider scanning

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -55,6 +55,8 @@ Follow these patterns exactly as they exist in the codebase:
 - New controller flags or environment variables must be reflected in the relevant `templates/<service>-deployment.yaml` and exposed as values in `values.yaml`
 - New RBAC rules added via kubebuilder markers must be mirrored in `templates/<service>-rbac.yaml`
 - Bump `version` in `chart/opendepot/Chart.yaml` when any chart file changes
+- Bump `appVersion` in `chart/opendepot/Chart.yaml` when any service image tag changes (e.g., `version` field in `values.yaml`)
+- Bump service image tag in `values.yaml` when any service code changes (e.g., `version` field under each service)
 
 ## Acceptance Criteria
 
@@ -69,7 +71,7 @@ Follow these patterns exactly as they exist in the codebase:
 ## Workflow
 
 ```
-1. Read plan from /memories/session/plan.md (or build context manually)
+1. Read plan from .session-memory/plan.md with memory tool — this is the ground truth for what to implement.
 2. Create todo list of all implementation steps
 3. Implement CRD/type changes first (api/v1alpha1/)
 4. Implement controller logic changes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
-[![Helm](https://img.shields.io/badge/Helm_Chart-0.1.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
+[![Helm](https://img.shields.io/badge/Helm_Chart-0.2.2-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
 [![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
 
 <p align="center">

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,12 @@ OpenDepot delegates auth entirely to Kubernetes — the platform you're likely a
 
     Checksums are written to Kubernetes status subresources (protected by RBAC) and verified on every reconciliation — not just at upload time.
 
+- :material-magnify-scan: &nbsp;__Built-In Vulnerability Scanning__
+
+    ---
+
+    The Version controller runs [Trivy](https://trivy.dev/) automatically on every provider binary, provider source (`go.mod`), and module archive. Findings are stored on the Kubernetes resource and can optionally block promotion of critical or high severity artifacts.
+
 </div>
 
 ## How OpenDepot Compares
@@ -65,6 +71,7 @@ OpenDepot delegates auth entirely to Kubernetes — the platform you're likely a
 | Version discovery | Automatic via Depot (GitHub + HashiCorp Releases APIs) | Manual upload or API push | Manual upload or API push |
 | Immutability enforcement | Checksum validated every reconciliation | At upload time only | At upload time only |
 | Air-gapped support | Yes (filesystem backend + PVC) | Yes (filesystem) | Limited |
+| Vulnerability scanning | Built-in (Trivy — provider binary, source, and module IaC) | No | No |
 
 !!! tip
     If you're already running Kubernetes, OpenDepot gives you a registry where security, auth, and operations come free — no extra infrastructure, no extra accounts, no extra attack surface.


### PR DESCRIPTION
This pull request updates documentation and workflow guidelines to clarify release and workflow processes, and introduces information about built-in vulnerability scanning. The main changes are improvements to the developer workflow, Helm chart versioning, and enhanced documentation about security features.

**Documentation and Feature Additions:**

* Added a section to the documentation highlighting built-in vulnerability scanning using Trivy, which automatically scans provider binaries, sources, and module archives, and can block promotion of critical or high severity artifacts.
* Updated the comparison table in the documentation to include the new built-in vulnerability scanning feature, distinguishing OpenDepot from other solutions.

**Release and Versioning Process Improvements:**

* Updated developer guidelines to require bumping the `appVersion` in `chart/opendepot/Chart.yaml` when any service image tag changes, and to bump the service image tag in `values.yaml` when service code changes.
* Updated the Helm chart badge in `README.md` to reflect the new version (`0.2.2`).

**Workflow and Process Clarifications:**

* Clarified the workflow to specify that the implementation plan should be read from `.session-memory/plan.md` using the memory tool, establishing this as the ground truth for implementation.