### PR TITLE
E2e test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
-[![Helm](https://img.shields.io/badge/Helm_Chart-0.2.2-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
+[![Helm](https://img.shields.io/badge/Helm_Chart-0.2.3-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
 [![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
 
 <p align="center">

--- a/chart/opendepot/Chart.yaml
+++ b/chart/opendepot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opendepot
 description: A Helm chart for deploying OpenDepot, a cloud-native OpenTofu Registry
 type: application
-version: 0.2.3
+version: 0.2.4
 appVersion: "0.2.2"
 keywords:
   - terraform

--- a/chart/opendepot/Chart.yaml
+++ b/chart/opendepot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opendepot
 description: A Helm chart for deploying OpenDepot, a cloud-native OpenTofu Registry
 type: application
-version: 0.2.4
-appVersion: "0.2.2"
+version: 0.2.3
+appVersion: "0.2.3"
 keywords:
   - terraform
   - opentofu

--- a/chart/opendepot/Chart.yaml
+++ b/chart/opendepot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opendepot
 description: A Helm chart for deploying OpenDepot, a cloud-native OpenTofu Registry
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: "0.2.2"
 keywords:
   - terraform

--- a/chart/opendepot/templates/version-deployment.yaml
+++ b/chart/opendepot/templates/version-deployment.yaml
@@ -43,14 +43,19 @@ spec:
       - name: version-controller
         image: "{{ .Values.version.image.repository }}:{{ default .Values.global.image.tag .Values.version.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-        {{- if .Values.scanning.enabled }}
+        {{- if or .Values.scanning.enabled .Values.version.zapLogLevel }}
         args:
+        {{- if .Values.scanning.enabled }}
         - --scanning-enabled=true
         - --trivy-cache-dir={{ .Values.scanning.cacheMountPath }}
         - --scan-offline={{ .Values.scanning.offline }}
         - --scan-block-on-critical={{ .Values.scanning.blockOnCritical }}
         - --scan-block-on-high={{ .Values.scanning.blockOnHigh }}
         - --scan-modules={{ .Values.scanning.scanModules }}
+        {{- end }}
+        {{- if .Values.version.zapLogLevel }}
+        - --zap-log-level={{ .Values.version.zapLogLevel }}
+        {{- end }}
         {{- end }}
         {{- if .Values.rbac.scopeToNamespace }}
         env:

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -13,6 +13,9 @@ global:
 version:
   enabled: true
   replicaCount: 1
+  # zapLogLevel sets --zap-log-level on the controller. Leave empty for the
+  # default (info). Set to 5 to enable verbose debug logging.
+  zapLogLevel: ""
   image:
     repository: ghcr.io/tonedefdev/opendepot/version-controller
     tag: ""

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -7,7 +7,7 @@ global:
   namespace: opendepot-system
   imagePullPolicy: IfNotPresent
   image:
-    tag: 0.2.2
+    tag: 0.2.3
 
 ## Version Service (Core - handles GitHub fetching and storage)
 version:

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -19,9 +19,9 @@ version:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     limits:
-      memory: 2Gi
+      memory: 4Gi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -19,9 +19,9 @@ version:
   resources:
     requests:
       cpu: 100m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      memory: 512Mi
+      memory: 2Gi
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/docs/configuration/scanning.md
+++ b/docs/configuration/scanning.md
@@ -43,22 +43,6 @@ The PVC must use a `StorageClass` that supports `ReadWriteMany` access so that t
 !!! note
     The Trivy DB (PVC + CronJob) is only required for **provider** binary and source scans. Module IaC scanning uses config rules bundled in the Trivy binary and works without a populated DB cache.
 
-## Memory Requirements
-
-When scanning is enabled, the version-controller loads the Trivy vulnerability database into memory during each reconciliation. The default memory limit of `512Mi` is insufficient for this workload and will cause the controller pod to be OOMKilled (exit code 137).
-
-Set `version.resources.limits.memory` to at least `2Gi` when scanning is enabled:
-
-```bash
-helm upgrade opendepot opendepot/opendepot \
-  --reuse-values \
-  --set scanning.enabled=true \
-  --set version.resources.limits.memory=2Gi \
-  --set version.resources.requests.memory=256Mi
-```
-
-The chart ships with these values as defaults from version `0.2.3` onwards, so a fresh install does not require the flags above.
-
 ## Enabling Scanning
 
 ```yaml

--- a/docs/configuration/scanning.md
+++ b/docs/configuration/scanning.md
@@ -43,6 +43,22 @@ The PVC must use a `StorageClass` that supports `ReadWriteMany` access so that t
 !!! note
     The Trivy DB (PVC + CronJob) is only required for **provider** binary and source scans. Module IaC scanning uses config rules bundled in the Trivy binary and works without a populated DB cache.
 
+## Memory Requirements
+
+When scanning is enabled, the version-controller loads the Trivy vulnerability database into memory during each reconciliation. The default memory limit of `512Mi` is insufficient for this workload and will cause the controller pod to be OOMKilled (exit code 137).
+
+Set `version.resources.limits.memory` to at least `2Gi` when scanning is enabled:
+
+```bash
+helm upgrade opendepot opendepot/opendepot \
+  --reuse-values \
+  --set scanning.enabled=true \
+  --set version.resources.limits.memory=2Gi \
+  --set version.resources.requests.memory=256Mi
+```
+
+The chart ships with these values as defaults from version `0.2.3` onwards, so a fresh install does not require the flags above.
+
 ## Enabling Scanning
 
 ```yaml

--- a/docs/guides/modules.md
+++ b/docs/guides/modules.md
@@ -23,6 +23,34 @@ module "aks" {
 
 The source format is `<registry-host>/<namespace>/<name>/<provider>`, where `<namespace>` is the Kubernetes namespace where the `Module` resource lives.
 
+## Inline Module Configuration
+
+`moduleConfigRef.name` is optional on a `Version` CR. When `name` is omitted, or when no `Module` CR with that name exists in the namespace, the Version controller treats all fields on `moduleConfigRef` as fully inline. A UUID-based filename is generated automatically so the archive has a stable storage key, and the download proceeds using the GitHub and storage config set directly on the `Version` CR.
+
+This is useful when running the version controller standalone (without the module controller), or for one-off version testing where creating a full `Module` CR is unnecessary.
+
+```yaml
+apiVersion: opendepot.defdev.io/v1alpha1
+kind: Version
+metadata:
+  name: terraform-aws-s3-bucket-4.3.0
+  namespace: opendepot-system
+spec:
+  type: Module
+  version: "4.3.0"
+  moduleConfigRef:
+    repoOwner: terraform-aws-modules
+    repoUrl: "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+    githubClientConfig:
+      useAuthenticatedClient: false
+    storageConfig:
+      fileSystem:
+        directoryPath: /data/modules
+```
+
+!!! note
+    When `name` is omitted the `Version` CR is completely self-contained. No `Module` CR needs to exist in the namespace.
+
 ## Vulnerability Scanning
 
 When [scanning is enabled](../configuration/scanning.md), the Version controller runs a Trivy IaC scan on the extracted module archive and stores findings on the `Version` resource.

--- a/module_test.yaml
+++ b/module_test.yaml
@@ -1,0 +1,16 @@
+apiVersion: opendepot.defdev.io/v1alpha1
+kind: Module
+metadata:
+  name: terraform-aws-s3-bucket
+  namespace: opendepot-system
+spec:
+  moduleConfig:
+    provider: aws
+    repoOwner: terraform-aws-modules
+    repoUrl: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket
+    fileFormat: zip
+    storageConfig:
+      fileSystem:
+        directoryPath: /data/modules
+  versions:
+    - version: "5.12.0"

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  🚀 <strong>OpenDepot v0.2.2</strong> is now available &mdash;
+  🚀 <strong>OpenDepot v0.2.3</strong> is now available &mdash;
   <a href="https://github.com/tonedefdev/opendepot/releases" target="_blank" rel="noopener">
     Release notes &nbsp;→
   </a>

--- a/pkg/storage/aws.go
+++ b/pkg/storage/aws.go
@@ -93,12 +93,19 @@ func (storage *AmazonS3Storage) DeleteObject(ctx context.Context, soi *storagety
 
 // PutObject puts the Version file in the specified bucket with its computed base64 encoded SHA256 checksum.
 func (storage *AmazonS3Storage) PutObject(ctx context.Context, soi *storagetypes.StorageObjectInput) error {
+	var body io.ReadSeeker
+	if soi.FileReader != nil {
+		body = soi.FileReader
+	} else {
+		body = bytes.NewReader(soi.FileBytes)
+	}
+
 	_, err := storage.client.PutObject(ctx, &s3.PutObjectInput{
 		ChecksumAlgorithm: types.ChecksumAlgorithmSha256,
 		ChecksumSHA256:    soi.ArchiveChecksum,
 		Bucket:            &soi.Version.Spec.ModuleConfigRef.StorageConfig.S3.Bucket,
 		Key:               soi.FilePath,
-		Body:              bytes.NewReader(soi.FileBytes),
+		Body:              body,
 	})
 	if err != nil {
 		return err

--- a/pkg/storage/azure.go
+++ b/pkg/storage/azure.go
@@ -106,11 +106,17 @@ func (storage *AzureBlobStorage) PutObject(ctx context.Context, soi *storagetype
 		return err
 	}
 
-	bufferOptions := &azblob.UploadBufferOptions{
-		Concurrency: 10,
+	if soi.FileReader != nil {
+		streamOptions := &azblob.UploadStreamOptions{
+			Concurrency: 10,
+		}
+		_, err = storage.blobClient.UploadStream(ctx, *ctr.Name, *soi.FilePath, soi.FileReader, streamOptions)
+	} else {
+		bufferOptions := &azblob.UploadBufferOptions{
+			Concurrency: 10,
+		}
+		_, err = storage.blobClient.UploadBuffer(ctx, *ctr.Name, *soi.FilePath, soi.FileBytes, bufferOptions)
 	}
-
-	_, err = storage.blobClient.UploadBuffer(ctx, *ctr.Name, *soi.FilePath, soi.FileBytes, bufferOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/filesystem.go
+++ b/pkg/storage/filesystem.go
@@ -58,13 +58,18 @@ func (storage *FileSystem) GetObjectChecksum(ctx context.Context, soi *types.Sto
 		return err
 	}
 
-	fileBytes, err := os.ReadFile(*soi.FilePath)
+	f, err := os.Open(*soi.FilePath)
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
-	sha256Sum := sha256.Sum256(fileBytes)
-	checksumSha256 := base64.StdEncoding.EncodeToString(sha256Sum[:])
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+
+	checksumSha256 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	soi.ObjectChecksum = &checksumSha256
 	soi.FileExists = true
 	return nil
@@ -97,12 +102,20 @@ func (storage *FileSystem) PutObject(ctx context.Context, soi *types.StorageObje
 		}
 	}
 
-	permissions := os.FileMode(0644)
-	if err := os.WriteFile(
-		*soi.FilePath,
-		soi.FileBytes,
-		permissions,
-	); err != nil {
+	out, err := os.OpenFile(*soi.FilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if soi.FileReader != nil {
+		if _, err := io.Copy(out, soi.FileReader); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if _, err := out.Write(soi.FileBytes); err != nil {
 		return err
 	}
 

--- a/pkg/storage/gcp.go
+++ b/pkg/storage/gcp.go
@@ -113,9 +113,16 @@ func (gcs *GoogleCloudStorage) PutObject(ctx context.Context, soi *storagetypes.
 	}
 
 	// Write the file bytes
-	if _, err := wc.Write(soi.FileBytes); err != nil {
-		wc.Close()
-		return err
+	if soi.FileReader != nil {
+		if _, err := io.Copy(wc, soi.FileReader); err != nil {
+			wc.Close()
+			return err
+		}
+	} else {
+		if _, err := wc.Write(soi.FileBytes); err != nil {
+			wc.Close()
+			return err
+		}
 	}
 
 	// Close the writer to finalize the upload

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"io"
+
 	versionv1alpha1 "github.com/tonedefdev/opendepot/api/v1alpha1"
 )
 
@@ -19,8 +21,12 @@ type StorageObjectInput struct {
 	ArchiveChecksum *string
 	// The storage method to use. One of 'Get', 'Delete', or 'Put'
 	Method StorageMethod
-	// The archive file as a bite slice.
+	// The archive file as a byte slice. For large files prefer FileReader to avoid
+	// loading the full artifact into the Go heap.
 	FileBytes []byte
+	// FileReader is an optional streaming source for Put operations. When set, storage
+	// backends use it instead of FileBytes, keeping large artifacts off the heap.
+	FileReader io.ReadSeeker
 	// A flag set to true when the storage system determines the file exists.
 	FileExists bool
 	// The file path of the storage object. This may be a reference to a cloud storage path such as an `AWS S3 Bucket` key or an `Azure Storage Blob`.

--- a/provider_test.yaml
+++ b/provider_test.yaml
@@ -1,0 +1,21 @@
+apiVersion: opendepot.defdev.io/v1alpha1
+kind: Provider
+metadata:
+  name: aws
+  namespace: opendepot-system
+spec:
+  providerConfig:
+    name: aws
+    namespace: hashicorp
+    sourceRepository: "https://github.com/hashicorp/terraform-provider-aws"
+    operatingSystems:
+      - linux
+      - darwin
+    architectures:
+      - amd64
+      - arm64
+    storageConfig:
+      fileSystem:
+        directoryPath: /data/modules
+  versions:
+    - version: "5.80.0"

--- a/services/version/internal/controller/opendepot_versions_controller.go
+++ b/services/version/internal/controller/opendepot_versions_controller.go
@@ -358,16 +358,8 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// temp file on disk instead.
 	var binaryScan *opendepotv1alpha1.ProviderBinaryScan
 	if r.ScanningEnabled && version.Spec.Type == opendepotv1alpha1.OpenDepotProvider && providerTmpPath != "" {
-		r.Log.V(5).Info("waiting for scan semaphore (provider binary scan)", "version", version.Name)
-		select {
-		case r.scanSem <- struct{}{}:
-		case <-ctx.Done():
-			return ctrl.Result{}, ctx.Err()
-		}
-
 		var scanErr error
 		binaryScan, scanErr = r.runProviderScan(ctx, version, providerTmpPath, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
-		<-r.scanSem
 		r.Log.V(5).Info("provider binary scan complete", "version", version.Name, "findingsPresent", binaryScan != nil)
 
 		if scanErr != nil {
@@ -382,16 +374,8 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// The scan result is returned here and written atomically in the final status update below.
 	var moduleScan *opendepotv1alpha1.ModuleSourceScan
 	if r.ScanningEnabled && r.ScanModules && version.Spec.Type == opendepotv1alpha1.OpenDepotModule && len(fileBytes) > 0 {
-		r.Log.V(5).Info("waiting for scan semaphore (module source scan)", "version", version.Name)
-		select {
-		case r.scanSem <- struct{}{}:
-		case <-ctx.Done():
-			return ctrl.Result{}, ctx.Err()
-		}
-
 		var scanErr error
 		moduleScan, scanErr = r.runModuleScan(ctx, version, fileBytes, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
-		<-r.scanSem
 		r.Log.V(5).Info("module source scan complete", "version", version.Name, "findingsPresent", moduleScan != nil)
 
 		if scanErr != nil {

--- a/services/version/internal/controller/opendepot_versions_controller.go
+++ b/services/version/internal/controller/opendepot_versions_controller.go
@@ -359,9 +359,15 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var binaryScan *opendepotv1alpha1.ProviderBinaryScan
 	if r.ScanningEnabled && version.Spec.Type == opendepotv1alpha1.OpenDepotProvider && providerTmpPath != "" {
 		r.Log.V(5).Info("waiting for scan semaphore (provider binary scan)", "version", version.Name)
+		select {
+		case r.scanSem <- struct{}{}:
+		case <-ctx.Done():
+			return ctrl.Result{}, ctx.Err()
+		}
 
 		var scanErr error
 		binaryScan, scanErr = r.runProviderScan(ctx, version, providerTmpPath, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
+		<-r.scanSem
 		r.Log.V(5).Info("provider binary scan complete", "version", version.Name, "findingsPresent", binaryScan != nil)
 
 		if scanErr != nil {
@@ -377,9 +383,15 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	var moduleScan *opendepotv1alpha1.ModuleSourceScan
 	if r.ScanningEnabled && r.ScanModules && version.Spec.Type == opendepotv1alpha1.OpenDepotModule && len(fileBytes) > 0 {
 		r.Log.V(5).Info("waiting for scan semaphore (module source scan)", "version", version.Name)
+		select {
+		case r.scanSem <- struct{}{}:
+		case <-ctx.Done():
+			return ctrl.Result{}, ctx.Err()
+		}
 
 		var scanErr error
 		moduleScan, scanErr = r.runModuleScan(ctx, version, fileBytes, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
+		<-r.scanSem
 		r.Log.V(5).Info("module source scan complete", "version", version.Name, "findingsPresent", moduleScan != nil)
 
 		if scanErr != nil {

--- a/services/version/internal/controller/opendepot_versions_controller.go
+++ b/services/version/internal/controller/opendepot_versions_controller.go
@@ -20,10 +20,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -61,6 +63,14 @@ type VersionReconciler struct {
 	ScanOffline     bool
 	BlockOnCritical bool
 	BlockOnHigh     bool
+	// scanSem limits the number of concurrent Trivy processes. Each Trivy
+	// invocation loads the full vulnerability DB (~2 GiB) so running more than
+	// one at a time risks OOMKill even with a generous container memory limit.
+	scanSem chan struct{}
+	// downloadSem limits the number of concurrent provider archive downloads.
+	// Each download streams a ~700 MB zip to disk; allowing all four workers to
+	// download simultaneously risks exhausting memory and disk I/O.
+	downloadSem chan struct{}
 }
 
 // +kubebuilder:rbac:groups=opendepot.defdev.io,resources=versions,verbs=get;list;watch;create;update;patch;delete
@@ -133,6 +143,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	var fileBytes []byte
 	var archiveChecksum *string
+	var providerTmpPath string
 
 	switch version.Spec.Type {
 	case opendepotv1alpha1.OpenDepotModule:
@@ -159,12 +170,42 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, statusMsg
 		}
 	case opendepotv1alpha1.OpenDepotProvider:
-		providerBytes, checksum, fileName, err := r.fetchProviderArchive(ctx, version)
+		// Fast path: if the Version has already been synced and the artifact exists in
+		// storage with a matching checksum, there is nothing to download or upload.
+		// Skipping the download is critical — /tmp is tmpfs (RAM-backed) in Linux
+		// containers, so downloading 700MB per worker on every reconcile exhausts memory.
+		if version.Status.Checksum != nil && version.Status.Synced && version.Spec.FileName != nil {
+			existingFilePath, pathErr := getVersionFilePath(version)
+			if pathErr == nil {
+				earlySoi := &types.StorageObjectInput{
+					Method:   types.Get,
+					FilePath: existingFilePath,
+					Version:  version,
+				}
+				if checkErr := r.InitStorageFactory(ctx, earlySoi); checkErr == nil &&
+					earlySoi.FileExists &&
+					earlySoi.ObjectChecksum != nil &&
+					*earlySoi.ObjectChecksum == *version.Status.Checksum {
+					return reconcile.Result{}, nil
+				}
+			}
+		}
+
+		// Serialize provider downloads: each is ~700 MB and concurrent downloads
+		// exhaust memory. The semaphore ensures only one download runs at a time.
+		select {
+		case r.downloadSem <- struct{}{}:
+		case <-ctx.Done():
+			return ctrl.Result{}, ctx.Err()
+		}
+		tmpPath, cleanupArchive, checksum, fileName, err := r.fetchProviderArchive(ctx, version)
+		<-r.downloadSem
 		if err != nil {
 			version.Status.SyncStatus = fmt.Sprintf("Failed to retrieve provider archive from HashiCorp releases API: %v", err)
 			_ = r.Status().Update(ctx, version)
 			return ctrl.Result{}, err
 		}
+		defer cleanupArchive()
 
 		if version.Spec.FileName == nil {
 			uuidFileName, err := generateProviderFileName(*fileName)
@@ -176,8 +217,8 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			version.Spec.FileName = uuidFileName
 		}
 
-		fileBytes = providerBytes
 		archiveChecksum = checksum
+		providerTmpPath = tmpPath
 	}
 
 	filePath, err := getVersionFilePath(version)
@@ -185,10 +226,28 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
+	// For providers the archive is on disk (providerTmpPath); open it as a ReadSeeker so
+	// storage backends can stream it without ever loading the full zip into the Go heap.
+	var providerFile *os.File
+	if providerTmpPath != "" {
+		pf, openErr := os.Open(providerTmpPath)
+		if openErr != nil {
+			version.Status.SyncStatus = fmt.Sprintf("Failed to open provider archive temp file: %v", openErr)
+			_ = r.Status().Update(ctx, version)
+			return ctrl.Result{}, openErr
+		}
+		defer pf.Close()
+		providerFile = pf
+	}
+
+	// hasArtifact indicates whether we have bytes (module) or a temp file (provider) to upload.
+	hasArtifact := len(fileBytes) > 0 || providerFile != nil
+
 	soi := &types.StorageObjectInput{
-		FileBytes: fileBytes,
-		FilePath:  filePath,
-		Version:   version,
+		FileBytes:  fileBytes,
+		FileReader: providerFile,
+		FilePath:   filePath,
+		Version:    version,
 	}
 
 	if version.Status.Checksum != nil {
@@ -197,7 +256,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 	} else {
-		if len(fileBytes) == 0 {
+		if !hasArtifact {
 			version.Status.Synced = false
 			version.Status.SyncStatus = "No artifact bytes available for upload yet"
 			_ = r.Status().Update(ctx, version)
@@ -211,11 +270,18 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if !soi.FileExists || (soi.ObjectChecksum != nil && version.Status.Checksum != nil && *soi.ObjectChecksum != *version.Status.Checksum) {
-		if len(fileBytes) == 0 {
+		if !hasArtifact {
 			version.Status.Synced = false
 			version.Status.SyncStatus = "Artifact missing in storage and no bytes available to reconcile"
 			_ = r.Status().Update(ctx, version)
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+
+		// Seek back to the start so the storage backend can re-read the provider archive.
+		if providerFile != nil {
+			if _, seekErr := providerFile.Seek(0, io.SeekStart); seekErr != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to seek provider archive: %w", seekErr)
+			}
 		}
 
 		soi.Method = types.Put
@@ -246,10 +312,15 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// The binary scan result is returned here and written in the final status
 	// update below so that all required fields (checksum, synced, syncStatus)
 	// are set atomically and satisfy CRD required-field validation.
+	//
+	// Free the in-memory zip bytes before invoking Trivy so that the ~700 MB
+	// provider archive and the ~2 GB Trivy vulnerability DB are never resident
+	// in the Go heap simultaneously. The scan reads the zip directly from the
+	// temp file on disk instead.
 	var binaryScan *opendepotv1alpha1.ProviderBinaryScan
-	if r.ScanningEnabled && version.Spec.Type == opendepotv1alpha1.OpenDepotProvider && len(fileBytes) > 0 {
+	if r.ScanningEnabled && version.Spec.Type == opendepotv1alpha1.OpenDepotProvider && providerTmpPath != "" {
 		var scanErr error
-		binaryScan, scanErr = r.runProviderScan(ctx, version, fileBytes, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
+		binaryScan, scanErr = r.runProviderScan(ctx, version, providerTmpPath, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
 		if scanErr != nil {
 			version.Status.Synced = false
 			version.Status.SyncStatus = fmt.Sprintf("Scan policy violation: %v", scanErr)
@@ -335,14 +406,40 @@ func (r *VersionReconciler) reconcileDeletion(ctx context.Context, version *open
 }
 
 // prepareModuleVersion resolves the backing Module metadata required to reconcile a module Version.
+// When moduleConfigRef.name is absent, or when no Module CR with that name exists in the namespace,
+// the config is treated as fully inline: a UUID filename is generated so getVersionFilePath has a
+// stable storage key, and the GitHub download proceeds using the fields already on moduleConfigRef.
 func (r *VersionReconciler) prepareModuleVersion(ctx context.Context, req ctrl.Request, version *opendepotv1alpha1.Version) (ctrl.Result, error) {
-	if version.Spec.ModuleConfigRef == nil || version.Spec.ModuleConfigRef.Name == nil {
-		return ctrl.Result{}, fmt.Errorf("moduleConfigRef.name is required for module version '%s'", version.Name)
+	if version.Spec.ModuleConfigRef == nil {
+		return ctrl.Result{}, fmt.Errorf("moduleConfigRef is required for module version '%s'", version.Name)
+	}
+
+	// No Module CR name provided — the caller supplied all config inline.
+	if version.Spec.ModuleConfigRef.Name == nil {
+		if version.Spec.FileName == nil {
+			uuidFileName, err := generateModuleFileName(version.Spec.ModuleConfigRef.FileFormat)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to generate UUID filename for module archive: %w", err)
+			}
+			version.Spec.FileName = uuidFileName
+		}
+		return ctrl.Result{}, nil
 	}
 
 	moduleObject := client.ObjectKey{Name: *version.Spec.ModuleConfigRef.Name, Namespace: req.Namespace}
 	module := &opendepotv1alpha1.Module{}
 	if err := r.Get(ctx, moduleObject, module); err != nil {
+		if k8serr.IsNotFound(err) {
+			// No backing Module CR — treat as inline config, using Name as the GitHub repo name.
+			if version.Spec.FileName == nil {
+				uuidFileName, err := generateModuleFileName(version.Spec.ModuleConfigRef.FileFormat)
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("failed to generate UUID filename for module archive: %w", err)
+				}
+				version.Spec.FileName = uuidFileName
+			}
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
 
@@ -415,6 +512,21 @@ func (r *VersionReconciler) fetchModuleArchive(ctx context.Context, version *ope
 	return opendepotGithub.GetModuleArchiveFromRef(ctx, r.Log, githubClient, version, fileFormat)
 }
 
+// generateModuleFileName returns a randomly generated UUID7 filename for a module archive.
+// The default extension is .tar.gz; pass fileFormat = "zip" to get a .zip extension.
+func generateModuleFileName(fileFormat *string) (*string, error) {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return nil, err
+	}
+	ext := ".tar.gz"
+	if fileFormat != nil && *fileFormat == "zip" {
+		ext = ".zip"
+	}
+	name := fmt.Sprintf("%s%s", id, ext)
+	return &name, nil
+}
+
 // generateProviderFileName returns a randomly generated UUID7 filename, preserving the original file extension.
 func generateProviderFileName(originalFileName string) (*string, error) {
 	id, err := uuid.NewV7()
@@ -427,20 +539,23 @@ func generateProviderFileName(originalFileName string) (*string, error) {
 	return &name, nil
 }
 
-// fetchProviderArchive resolves a provider binary download from the OpenTofu registry and downloads the artifact.
-func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *opendepotv1alpha1.Version) ([]byte, *string, *string, error) {
+// fetchProviderArchive resolves a provider binary download from the OpenTofu registry
+// and streams the artifact to a temporary file on disk to avoid buffering the
+// full provider zip (~700 MB) in the Go heap. The caller must invoke the returned
+// cleanup function (typically via defer) to remove the temp file.
+func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *opendepotv1alpha1.Version) (archivePath string, cleanup func(), checksum *string, fileName *string, err error) {
 	if version.Spec.ProviderConfigRef == nil || version.Spec.ProviderConfigRef.Name == nil {
-		return nil, nil, nil, fmt.Errorf("providerConfigRef.name is required")
+		return "", func() {}, nil, nil, fmt.Errorf("providerConfigRef.name is required")
 	}
 
 	if strings.TrimSpace(version.Spec.OperatingSystem) == "" || strings.TrimSpace(version.Spec.Architecture) == "" {
-		return nil, nil, nil, fmt.Errorf("provider operatingSystem and architecture are required")
+		return "", func() {}, nil, nil, fmt.Errorf("provider operatingSystem and architecture are required")
 	}
 
 	providerName := strings.TrimSpace(*version.Spec.ProviderConfigRef.Name)
 	providerVersion := strings.TrimPrefix(strings.TrimSpace(version.Spec.Version), "v")
 	if providerVersion == "" {
-		return nil, nil, nil, fmt.Errorf("provider version is empty")
+		return "", func() {}, nil, nil, fmt.Errorf("provider version is empty")
 	}
 
 	providerNamespace := "hashicorp"
@@ -453,36 +568,38 @@ func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *o
 	download, err := lookupProviderDownload(ctx, providerNamespace, providerName, providerVersion,
 		version.Spec.OperatingSystem, version.Spec.Architecture)
 	if err != nil {
-		return nil, nil, nil, err
+		return "", func() {}, nil, nil, err
 	}
 
-	fileBytes, err := httpGetBytes(ctx, download.DownloadURL)
+	tmpPath, checksumHex, cleanupFn, err := httpStreamToFile(ctx, download.DownloadURL)
 	if err != nil {
-		return nil, nil, nil, err
+		return "", func() {}, nil, nil, err
 	}
-
-	checksumRaw := sha256.Sum256(fileBytes)
 
 	// Validate the downloaded archive against the registry-provided SHA256.
 	if download.Shasum != "" {
-		if got := fmt.Sprintf("%x", checksumRaw); got != strings.ToLower(download.Shasum) {
-			return nil, nil, nil, fmt.Errorf("checksum mismatch for provider archive %s: registry expected %s, got %s",
-				download.Filename, download.Shasum, got)
+		if checksumHex != strings.ToLower(download.Shasum) {
+			cleanupFn()
+			return "", func() {}, nil, nil, fmt.Errorf("checksum mismatch for provider archive %s: registry expected %s, got %s",
+				download.Filename, download.Shasum, checksumHex)
 		}
 	}
 
-	checksum := base64.StdEncoding.EncodeToString(checksumRaw[:])
+	// Re-encode the hex SHA-256 as base64 for storage (matches the existing format).
+	checksumBytes, _ := hex.DecodeString(checksumHex)
+	checksumB64 := base64.StdEncoding.EncodeToString(checksumBytes)
 
-	fileName := download.Filename
-	if fileName == "" {
-		fileName = path.Base(download.DownloadURL)
+	fn := download.Filename
+	if fn == "" {
+		fn = path.Base(download.DownloadURL)
 	}
 
-	if fileName == "." || fileName == "/" || fileName == "" {
-		return nil, nil, nil, fmt.Errorf("unable to determine filename from provider download URL '%s'", download.DownloadURL)
+	if fn == "." || fn == "/" || fn == "" {
+		cleanupFn()
+		return "", func() {}, nil, nil, fmt.Errorf("unable to determine filename from provider download URL '%s'", download.DownloadURL)
 	}
 
-	return fileBytes, &checksum, &fileName, nil
+	return tmpPath, cleanupFn, &checksumB64, &fn, nil
 }
 
 // httpGetJSON performs an HTTP GET and unmarshals the response payload into out.
@@ -500,13 +617,15 @@ func httpGetJSON(ctx context.Context, requestURL string, out any) error {
 }
 
 // httpGetBytes performs an HTTP GET and returns the raw response body bytes.
+// Use httpStreamToFile for large downloads (e.g. provider binaries) to avoid
+// buffering the full body in the Go heap.
 func httpGetBytes(ctx context.Context, requestURL string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	client := &http.Client{Timeout: 30 * time.Second}
+	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request failed for '%s': %w", requestURL, err)
@@ -525,8 +644,60 @@ func httpGetBytes(ctx context.Context, requestURL string) ([]byte, error) {
 	return fileBytes, nil
 }
 
+// httpStreamToFile streams an HTTP GET response body to a temporary file on disk
+// while computing its SHA-256 checksum via an io.TeeReader. It returns the temp
+// file path, the hex-encoded checksum, a cleanup function that removes the file,
+// and any error. This avoids buffering large provider binaries (~700 MB) in the
+// Go heap, which is critical when multiple reconcilers run concurrently.
+func httpStreamToFile(ctx context.Context, requestURL string) (filePath string, checksumHex string, cleanup func(), err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", "", func() {}, err
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", func() {}, fmt.Errorf("request failed for '%s': %w", requestURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", "", func() {}, fmt.Errorf("request to '%s' failed with status %d", requestURL, resp.StatusCode)
+	}
+
+	f, err := os.CreateTemp("", "opendepot-provider-*.zip")
+	if err != nil {
+		return "", "", func() {}, fmt.Errorf("failed to create temp file for provider download: %w", err)
+	}
+
+	cleanupFn := func() {
+		f.Close()
+		os.Remove(f.Name())
+	}
+
+	h := sha256.New()
+	if _, err = io.Copy(f, io.TeeReader(resp.Body, h)); err != nil {
+		cleanupFn()
+		return "", "", func() {}, fmt.Errorf("failed to stream provider archive from '%s': %w", requestURL, err)
+	}
+
+	if err = f.Sync(); err != nil {
+		cleanupFn()
+		return "", "", func() {}, fmt.Errorf("failed to sync provider archive temp file: %w", err)
+	}
+
+	return f.Name(), fmt.Sprintf("%x", h.Sum(nil)), cleanupFn, nil
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *VersionReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Allow at most one Trivy process at a time to prevent concurrent DB loads
+	// from exhausting container memory when multiple reconcilers run in parallel.
+	r.scanSem = make(chan struct{}, 1)
+	// Allow at most one provider archive download at a time. Each download is
+	// ~700 MB; concurrent downloads exhaust memory and storage I/O.
+	r.downloadSem = make(chan struct{}, 1)
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&opendepotv1alpha1.Version{}).
 		Named(opendepotControllerName).

--- a/services/version/internal/controller/opendepot_versions_controller.go
+++ b/services/version/internal/controller/opendepot_versions_controller.go
@@ -133,12 +133,18 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	if version.Spec.ModuleConfigRef != nil && version.Spec.ProviderConfigRef != nil {
+		r.Log.V(5).Info("dual-config guard: both moduleConfigRef and providerConfigRef are set; writing terminal status",
+			"version", version.Name,
+		)
 		version.Status.Synced = false
 		version.Status.SyncStatus = "Only one of 'ModuleConfigRef' or 'ProviderConfigRef' can be provided: both are defined"
 		if err := r.Status().Update(ctx, version); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, fmt.Errorf("invalid version config: both moduleConfigRef and providerConfigRef are defined")
+		// This is a permanent user configuration error that cannot be resolved by
+		// requeuing. Return without an error so controller-runtime does not log a
+		// "Reconciler error" and does not schedule unnecessary backoff retries.
+		return ctrl.Result{}, nil
 	}
 
 	var fileBytes []byte
@@ -147,6 +153,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	switch version.Spec.Type {
 	case opendepotv1alpha1.OpenDepotModule:
+		r.Log.V(5).Info("fetching module archive", "version", version.Name, "versionStr", version.Spec.Version)
 		moduleBytes, checksum, err := r.fetchModuleArchive(ctx, version)
 		if err != nil {
 			version.Status.SyncStatus = fmt.Sprintf("Failed to retrieve module archive: %v", err)
@@ -154,6 +161,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 
+		r.Log.V(5).Info("module archive fetched", "version", version.Name, "bytes", len(moduleBytes))
 		fileBytes = moduleBytes
 		archiveChecksum = checksum
 
@@ -170,6 +178,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, statusMsg
 		}
 	case opendepotv1alpha1.OpenDepotProvider:
+		r.Log.V(5).Info("checking provider fast-path", "version", version.Name, "synced", version.Status.Synced, "checksumSet", version.Status.Checksum != nil)
 		// Fast path: if the Version has already been synced and the artifact exists in
 		// storage with a matching checksum, there is nothing to download or upload.
 		// Skipping the download is critical — /tmp is tmpfs (RAM-backed) in Linux
@@ -186,6 +195,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 					earlySoi.FileExists &&
 					earlySoi.ObjectChecksum != nil &&
 					*earlySoi.ObjectChecksum == *version.Status.Checksum {
+					r.Log.V(5).Info("provider fast-path hit: artifact exists with matching checksum; skipping download", "version", version.Name)
 					return reconcile.Result{}, nil
 				}
 			}
@@ -193,18 +203,26 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 		// Serialize provider downloads: each is ~700 MB and concurrent downloads
 		// exhaust memory. The semaphore ensures only one download runs at a time.
+		r.Log.V(5).Info("waiting for download semaphore", "version", version.Name)
 		select {
 		case r.downloadSem <- struct{}{}:
 		case <-ctx.Done():
 			return ctrl.Result{}, ctx.Err()
 		}
+
+		r.Log.V(5).Info("download semaphore acquired; fetching provider archive", "version", version.Name)
 		tmpPath, cleanupArchive, checksum, fileName, err := r.fetchProviderArchive(ctx, version)
+
 		<-r.downloadSem
+		r.Log.V(5).Info("download semaphore released", "version", version.Name)
+
 		if err != nil {
 			version.Status.SyncStatus = fmt.Sprintf("Failed to retrieve provider archive from HashiCorp releases API: %v", err)
 			_ = r.Status().Update(ctx, version)
 			return ctrl.Result{}, err
 		}
+
+		r.Log.V(5).Info("provider archive fetched", "version", version.Name, "tmpPath", tmpPath)
 		defer cleanupArchive()
 
 		if version.Spec.FileName == nil {
@@ -214,6 +232,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				_ = r.Status().Update(ctx, version)
 				return ctrl.Result{}, err
 			}
+
 			version.Spec.FileName = uuidFileName
 		}
 
@@ -223,7 +242,16 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	filePath, err := getVersionFilePath(version)
 	if err != nil {
-		return ctrl.Result{}, err
+		// FileName is nil — the spec update that persists it from a previous
+		// reconcile has not propagated yet (e.g. the update was lost to a
+		// conflict). Write a status message and requeue; do not return an error
+		// or controller-runtime will log "Reconciler error" and backoff-requeue
+		// indefinitely for what is a transient state.
+		r.Log.V(5).Info("cannot compute file path; requeueing", "version", version.Name, "reason", err.Error())
+		version.Status.Synced = false
+		version.Status.SyncStatus = fmt.Sprintf("Waiting for file path to be available: %v", err)
+		_ = r.Status().Update(ctx, version)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// For providers the archive is on disk (providerTmpPath); open it as a ReadSeeker so
@@ -236,6 +264,7 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			_ = r.Status().Update(ctx, version)
 			return ctrl.Result{}, openErr
 		}
+
 		defer pf.Close()
 		providerFile = pf
 	}
@@ -244,17 +273,23 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	hasArtifact := len(fileBytes) > 0 || providerFile != nil
 
 	soi := &types.StorageObjectInput{
-		FileBytes:  fileBytes,
-		FileReader: providerFile,
-		FilePath:   filePath,
-		Version:    version,
+		FileBytes: fileBytes,
+		FilePath:  filePath,
+		Version:   version,
+	}
+
+	if providerFile != nil {
+		soi.FileReader = providerFile
 	}
 
 	if version.Status.Checksum != nil {
+		r.Log.V(5).Info("status checksum set; performing storage get to verify artifact", "version", version.Name)
 		soi.Method = types.Get
 		if err = r.InitStorageFactory(ctx, soi); err != nil {
 			return ctrl.Result{}, err
 		}
+
+		r.Log.V(5).Info("storage get complete", "version", version.Name, "fileExists", soi.FileExists)
 	} else {
 		if !hasArtifact {
 			version.Status.Synced = false
@@ -263,10 +298,12 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 
+		r.Log.V(5).Info("no status checksum; uploading artifact", "version", version.Name)
 		soi.Method = types.Put
 		if err = r.InitStorageFactory(ctx, soi); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.Log.V(5).Info("initial storage put complete", "version", version.Name)
 	}
 
 	if !soi.FileExists || (soi.ObjectChecksum != nil && version.Status.Checksum != nil && *soi.ObjectChecksum != *version.Status.Checksum) {
@@ -284,10 +321,12 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 		}
 
+		r.Log.V(5).Info("artifact missing or checksum mismatch; re-uploading", "version", version.Name, "fileExists", soi.FileExists)
 		soi.Method = types.Put
 		if err = r.InitStorageFactory(ctx, soi); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.Log.V(5).Info("re-upload storage put complete", "version", version.Name)
 	}
 
 	if err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -319,8 +358,12 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// temp file on disk instead.
 	var binaryScan *opendepotv1alpha1.ProviderBinaryScan
 	if r.ScanningEnabled && version.Spec.Type == opendepotv1alpha1.OpenDepotProvider && providerTmpPath != "" {
+		r.Log.V(5).Info("waiting for scan semaphore (provider binary scan)", "version", version.Name)
+
 		var scanErr error
 		binaryScan, scanErr = r.runProviderScan(ctx, version, providerTmpPath, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
+		r.Log.V(5).Info("provider binary scan complete", "version", version.Name, "findingsPresent", binaryScan != nil)
+
 		if scanErr != nil {
 			version.Status.Synced = false
 			version.Status.SyncStatus = fmt.Sprintf("Scan policy violation: %v", scanErr)
@@ -333,8 +376,12 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// The scan result is returned here and written atomically in the final status update below.
 	var moduleScan *opendepotv1alpha1.ModuleSourceScan
 	if r.ScanningEnabled && r.ScanModules && version.Spec.Type == opendepotv1alpha1.OpenDepotModule && len(fileBytes) > 0 {
+		r.Log.V(5).Info("waiting for scan semaphore (module source scan)", "version", version.Name)
+
 		var scanErr error
 		moduleScan, scanErr = r.runModuleScan(ctx, version, fileBytes, r.TrivyCacheDir, r.ScanOffline, r.BlockOnCritical, r.BlockOnHigh)
+		r.Log.V(5).Info("module source scan complete", "version", version.Name, "findingsPresent", moduleScan != nil)
+
 		if scanErr != nil {
 			version.Status.Synced = false
 			version.Status.SyncStatus = fmt.Sprintf("Scan policy violation: %v", scanErr)
@@ -379,13 +426,26 @@ func (r *VersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // reconcileDeletion removes the stored artifact and finalizer when a Version is being deleted.
 func (r *VersionReconciler) reconcileDeletion(ctx context.Context, version *opendepotv1alpha1.Version) (ctrl.Result, error) {
+	r.Log.V(5).Info("reconciling deletion", "version", version.Name)
 	if !controllerutil.ContainsFinalizer(version, opendepotv1alpha1.OpenDepotFinalizer) {
+		r.Log.V(5).Info("no finalizer present; skipping deletion reconciliation", "version", version.Name)
 		return ctrl.Result{}, nil
 	}
 
 	filePath, err := getVersionFilePath(version)
 	if err != nil {
-		return ctrl.Result{}, err
+		// If the file path cannot be resolved (e.g. FileName was never persisted
+		// because the Version was deleted before its first successful sync), there
+		// is no stored artifact to remove. Skip storage deletion and proceed
+		// directly to finalizer removal so the object is not stuck terminating.
+		r.Log.V(5).Info("skipping storage deletion: cannot resolve file path; removing finalizer directly",
+			"version", version.Name, "reason", err.Error(),
+		)
+		controllerutil.RemoveFinalizer(version, opendepotv1alpha1.OpenDepotFinalizer)
+		if err := r.Update(ctx, version); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	soi := &types.StorageObjectInput{
@@ -393,10 +453,13 @@ func (r *VersionReconciler) reconcileDeletion(ctx context.Context, version *open
 		FilePath: filePath,
 		Version:  version,
 	}
+
+	r.Log.V(5).Info("deleting stored artifact", "version", version.Name, "filePath", filePath)
 	if err := r.InitStorageFactory(ctx, soi); err != nil {
 		return ctrl.Result{}, err
 	}
 
+	r.Log.V(5).Info("artifact deleted; removing finalizer", "version", version.Name)
 	controllerutil.RemoveFinalizer(version, opendepotv1alpha1.OpenDepotFinalizer)
 	if err := r.Update(ctx, version); err != nil {
 		return ctrl.Result{}, err
@@ -444,12 +507,32 @@ func (r *VersionReconciler) prepareModuleVersion(ctx context.Context, req ctrl.R
 	}
 
 	if module.Status.ModuleVersionRefs == nil {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		// Module CR exists but the module controller has not populated any refs yet
+		// (e.g. the module controller is not deployed in this environment). Fall back
+		// to inline mode so the version controller can operate independently.
+		if version.Spec.FileName == nil {
+			uuidFileName, err := generateModuleFileName(version.Spec.ModuleConfigRef.FileFormat)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to generate UUID filename for module archive: %w", err)
+			}
+			version.Spec.FileName = uuidFileName
+		}
+		return ctrl.Result{}, nil
 	}
 
 	moduleRef, exists := module.Status.ModuleVersionRefs[version.Spec.Version]
 	if !exists || moduleRef == nil || moduleRef.FileName == nil {
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		// The Module CR exists but has no ref for this specific version — the module
+		// controller may not be deployed or has not reconciled this version yet. Fall
+		// back to inline mode so this Version can be synced independently.
+		if version.Spec.FileName == nil {
+			uuidFileName, err := generateModuleFileName(version.Spec.ModuleConfigRef.FileFormat)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to generate UUID filename for module archive: %w", err)
+			}
+			version.Spec.FileName = uuidFileName
+		}
+		return ctrl.Result{}, nil
 	}
 
 	version.Spec.ModuleConfigRef = &module.Spec.ModuleConfig
@@ -544,6 +627,7 @@ func generateProviderFileName(originalFileName string) (*string, error) {
 // full provider zip (~700 MB) in the Go heap. The caller must invoke the returned
 // cleanup function (typically via defer) to remove the temp file.
 func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *opendepotv1alpha1.Version) (archivePath string, cleanup func(), checksum *string, fileName *string, err error) {
+	r.Log.V(5).Info("looking up provider download URL", "version", version.Name, "versionStr", version.Spec.Version, "os", version.Spec.OperatingSystem, "arch", version.Spec.Architecture)
 	if version.Spec.ProviderConfigRef == nil || version.Spec.ProviderConfigRef.Name == nil {
 		return "", func() {}, nil, nil, fmt.Errorf("providerConfigRef.name is required")
 	}
@@ -570,6 +654,7 @@ func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *o
 	if err != nil {
 		return "", func() {}, nil, nil, err
 	}
+	r.Log.V(5).Info("provider download URL resolved; streaming archive", "version", version.Name, "url", download.DownloadURL, "filename", download.Filename)
 
 	tmpPath, checksumHex, cleanupFn, err := httpStreamToFile(ctx, download.DownloadURL)
 	if err != nil {
@@ -583,6 +668,7 @@ func (r *VersionReconciler) fetchProviderArchive(ctx context.Context, version *o
 			return "", func() {}, nil, nil, fmt.Errorf("checksum mismatch for provider archive %s: registry expected %s, got %s",
 				download.Filename, download.Shasum, checksumHex)
 		}
+		r.Log.V(5).Info("provider archive checksum verified", "version", version.Name, "sha256", checksumHex)
 	}
 
 	// Re-encode the hex SHA-256 as base64 for storage (matches the existing format).

--- a/services/version/internal/controller/opendepot_versions_controller_test.go
+++ b/services/version/internal/controller/opendepot_versions_controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Version Controller", func() {
 			}
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: namespacedName})
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("moduleConfigRef.name is required"))
+			Expect(err.Error()).To(ContainSubstring("moduleConfigRef is required"))
 		})
 	})
 })

--- a/services/version/internal/controller/scanner.go
+++ b/services/version/internal/controller/scanner.go
@@ -157,14 +157,16 @@ func resolveProviderSourceRepository(ctx context.Context, namespace, providerNam
 		strings.TrimSpace(namespace), strings.TrimSpace(providerName))
 }
 
-// extractBinaryFromZip extracts the provider executable from a HashiCorp release zip.
-// The zip contains exactly one file: the compiled provider binary. We skip any
-// accompanying README or LICENSE files by filtering on common non-binary suffixes.
-func extractBinaryFromZip(archiveBytes []byte) ([]byte, error) {
-	zr, err := zip.NewReader(bytes.NewReader(archiveBytes), int64(len(archiveBytes)))
+// extractBinaryFromZip extracts the provider executable from a HashiCorp release zip
+// at archivePath on disk. The zip contains exactly one file: the compiled provider
+// binary. We skip any accompanying README or LICENSE files by filtering on common
+// non-binary suffixes and the absence of the executable bit.
+func extractBinaryFromZip(archivePath string) ([]byte, error) {
+	zr, err := zip.OpenReader(archivePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open provider zip archive: %w", err)
 	}
+	defer zr.Close()
 
 	for _, f := range zr.File {
 		if f.FileInfo().IsDir() {
@@ -208,11 +210,13 @@ func downloadGoMod(ctx context.Context, repoURL, version string, githubClient *g
 	return opendepotGithub.GetProviderGoMod(ctx, githubClient, parts[0], parts[1], version)
 }
 
-// scanProviderBinary runs `trivy rootfs` against the provider executable extracted from archiveBytes.
-// archiveBytes is the raw HashiCorp release zip. The binary is extracted before scanning.
+// scanProviderBinary runs `trivy rootfs` against the provider executable extracted
+// from the zip at archivePath on disk. Reading from disk (rather than from a []byte
+// held in the Go heap) ensures the full ~700 MB provider archive and the ~2 GB
+// Trivy vulnerability DB are never resident in memory simultaneously.
 // When offline is true, --offline-scan is passed to Trivy so it does not attempt network calls.
-func (r *VersionReconciler) scanProviderBinary(ctx context.Context, archiveBytes []byte, cacheDir string, offline bool) ([]opendepotv1alpha1.SecurityFinding, error) {
-	binaryBytes, err := extractBinaryFromZip(archiveBytes)
+func (r *VersionReconciler) scanProviderBinary(ctx context.Context, archivePath string, cacheDir string, offline bool) ([]opendepotv1alpha1.SecurityFinding, error) {
+	binaryBytes, err := extractBinaryFromZip(archivePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract binary from provider archive: %w", err)
 	}
@@ -234,7 +238,14 @@ func (r *VersionReconciler) scanProviderBinary(ctx context.Context, archiveBytes
 	}
 	args = append(args, "--cache-dir", cacheDir, "--quiet", tmpDir)
 
+	// Serialise Trivy invocations: each process loads the full ~2 GiB DB.
+	select {
+	case r.scanSem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	output, err := runTrivy(ctx, args...)
+	<-r.scanSem
 	if err != nil {
 		return nil, fmt.Errorf("binary scan failed: %w", err)
 	}
@@ -278,7 +289,14 @@ func (r *VersionReconciler) scanProviderSource(ctx context.Context, repoURL, ver
 	}
 	args = append(args, "--cache-dir", cacheDir, "--quiet", tmpDir)
 
+	// Serialise Trivy invocations: each process loads the full ~2 GiB DB.
+	select {
+	case r.scanSem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	output, err := runTrivy(ctx, args...)
+	<-r.scanSem
 	if err != nil {
 		return nil, fmt.Errorf("source scan failed: %w", err)
 	}
@@ -293,6 +311,7 @@ func (r *VersionReconciler) scanProviderSource(ctx context.Context, repoURL, ver
 }
 
 // runProviderScan orchestrates source and binary Trivy scans for a provider Version.
+// archivePath is the path to the provider zip on disk (as written by httpStreamToFile).
 // It returns the binary scan result (if successful) to be persisted by the caller
 // alongside the other status fields, avoiding partial status updates that would
 // violate the CRD required-field validation (checksum, synced, syncStatus are all
@@ -306,7 +325,7 @@ func (r *VersionReconciler) scanProviderSource(ctx context.Context, repoURL, ver
 func (r *VersionReconciler) runProviderScan(
 	ctx context.Context,
 	version *opendepotv1alpha1.Version,
-	archiveBytes []byte,
+	archivePath string,
 	cacheDir string,
 	offline bool,
 	blockOnCritical bool,
@@ -319,7 +338,7 @@ func (r *VersionReconciler) runProviderScan(
 
 	// Binary scan (always runs, unique per OS/arch)
 	var binaryScan *opendepotv1alpha1.ProviderBinaryScan
-	binaryFindings, err := r.scanProviderBinary(ctx, archiveBytes, cacheDir, offline)
+	binaryFindings, err := r.scanProviderBinary(ctx, archivePath, cacheDir, offline)
 	if err != nil {
 		r.Log.Error(err, "Binary scan failed — continuing without scan results",
 			"version", version.Name)
@@ -551,7 +570,14 @@ func (r *VersionReconciler) scanModuleArchive(ctx context.Context, archiveBytes 
 	// the vulnerability DB, so this works correctly with --offline-scan.
 	args := []string{"fs", "--format", "json", "--scanners", "misconfig"}
 
+	// Serialise Trivy invocations: each process loads the full ~2 GiB DB.
+	select {
+	case r.scanSem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	output, err := runTrivy(ctx, args...)
+	<-r.scanSem
 	if err != nil {
 		return nil, fmt.Errorf("module source scan failed: %w", err)
 	}

--- a/services/version/internal/controller/scanner.go
+++ b/services/version/internal/controller/scanner.go
@@ -568,7 +568,7 @@ func (r *VersionReconciler) scanModuleArchive(ctx context.Context, archiveBytes 
 	// --scanners misconfig is required: trivy fs defaults to vuln,secret only.
 	// Config-class (IaC) rules are bundled in the Trivy binary and do not need
 	// the vulnerability DB, so this works correctly with --offline-scan.
-	args := []string{"fs", "--format", "json", "--scanners", "misconfig"}
+	args := []string{"fs", "--format", "json", "--scanners", "misconfig", tmpDir}
 
 	// Serialise Trivy invocations: each process loads the full ~2 GiB DB.
 	select {

--- a/services/version/internal/controller/scanner.go
+++ b/services/version/internal/controller/scanner.go
@@ -176,6 +176,10 @@ func extractBinaryFromZip(archiveBytes []byte) ([]byte, error) {
 			continue
 		}
 
+		if f.Mode()&0111 == 0 {
+			continue
+		}
+
 		rc, err := f.Open()
 		if err != nil {
 			return nil, fmt.Errorf("failed to open %s in provider zip: %w", f.Name, err)
@@ -542,11 +546,10 @@ func (r *VersionReconciler) scanModuleArchive(ctx context.Context, archiveBytes 
 		return nil, fmt.Errorf("failed to extract module archive: %w", err)
 	}
 
-	args := []string{"fs", "--format", "json"}
-	if offline {
-		args = append(args, "--offline-scan")
-	}
-	args = append(args, "--cache-dir", cacheDir, "--quiet", tmpDir)
+	// --scanners misconfig is required: trivy fs defaults to vuln,secret only.
+	// Config-class (IaC) rules are bundled in the Trivy binary and do not need
+	// the vulnerability DB, so this works correctly with --offline-scan.
+	args := []string{"fs", "--format", "json", "--scanners", "misconfig"}
 
 	output, err := runTrivy(ctx, args...)
 	if err != nil {

--- a/services/version/test/e2e/e2e_suite_test.go
+++ b/services/version/test/e2e/e2e_suite_test.go
@@ -118,6 +118,9 @@ var _ = BeforeSuite(func() {
 		"--set", fmt.Sprintf("server.image.tag=%s", serverTag),
 		"--set", "storage.filesystem.enabled=true",
 		"--set", "storage.filesystem.hostPath=/data/modules",
+		"--set", "scanning.enabled=true",
+		"--set", "scanning.scanModules=true",
+		"--set", "scanning.cache.accessMode=ReadWriteOnce",
 		"--wait",
 		"--timeout", "3m",
 	)

--- a/services/version/test/e2e/e2e_suite_test.go
+++ b/services/version/test/e2e/e2e_suite_test.go
@@ -121,6 +121,7 @@ var _ = BeforeSuite(func() {
 		"--set", "scanning.enabled=true",
 		"--set", "scanning.scanModules=true",
 		"--set", "scanning.cache.accessMode=ReadWriteOnce",
+		"--set", "version.zapLogLevel=5",
 		"--wait",
 		"--timeout", "3m",
 	)

--- a/services/version/test/e2e/e2e_test.go
+++ b/services/version/test/e2e/e2e_test.go
@@ -256,15 +256,15 @@ spec:
 					"expected Version CR to reach synced=true")
 			}, 5*time.Minute, 10*time.Second).Should(Succeed())
 
-			By("asserting that status.sourceScan.findings contains at least one AVD- rule ID")
+			By("asserting that status.sourceScan.findings contains at least one security finding")
 			cmd = exec.Command("kubectl", "get", "version", scanVersionName,
 				"-n", namespace,
 				"-o", "jsonpath={.status.sourceScan.findings}",
 			)
 			findings, err := utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(findings).To(ContainSubstring("AVD-"),
-				"expected sourceScan.findings to contain at least one AVD- rule ID")
+			Expect(findings).To(ContainSubstring("vulnerabilityID"),
+				"expected sourceScan.findings to contain at least one security finding")
 		})
 	})
 })

--- a/services/version/test/e2e/e2e_test.go
+++ b/services/version/test/e2e/e2e_test.go
@@ -198,4 +198,73 @@ spec:
 			}, 2*time.Minute).Should(Succeed())
 		})
 	})
+
+	Context("Module IaC Scan", Ordered, func() {
+		const (
+			scanVersionName = "terraform-aws-s3-bucket-4.3.0"
+			scanModuleName  = "terraform-aws-s3-bucket"
+			scanVersion     = "4.3.0"
+			scanRepoOwner   = "terraform-aws-modules"
+			scanRepoURL     = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+			scanStorageDir  = "/data/modules"
+		)
+
+		AfterAll(func() {
+			By("removing the Module IaC Scan Version CR")
+			cmd := exec.Command("kubectl", "delete", "version", scanVersionName,
+				"-n", namespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should produce IaC findings for a module with known misconfigurations", func() {
+			By("applying an inline module Version CR for terraform-aws-s3-bucket 4.3.0")
+			versionYAML := fmt.Sprintf(`apiVersion: opendepot.defdev.io/v1alpha1
+kind: Version
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  type: Module
+  version: %q
+  moduleConfigRef:
+    name: %q
+    repoOwner: %q
+    repoUrl: %q
+    githubClientConfig:
+      useAuthenticatedClient: false
+    storageConfig:
+      fileSystem:
+        directoryPath: %s
+`, scanVersionName, namespace, scanVersion, scanModuleName, scanRepoOwner, scanRepoURL, scanStorageDir)
+
+			versionFile := filepath.Join(GinkgoT().TempDir(), "scan-version.yaml")
+			Expect(os.WriteFile(versionFile, []byte(versionYAML), 0600)).To(Succeed())
+
+			cmd := exec.Command("kubectl", "apply", "-f", versionFile)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply Module IaC Scan Version CR")
+
+			By("waiting for the Version CR to reach synced=true (network download involved)")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "version", scanVersionName,
+					"-n", namespace,
+					"-o", "jsonpath={.status.synced}",
+				)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"),
+					"expected Version CR to reach synced=true")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+			By("asserting that status.sourceScan.findings contains at least one AVD- rule ID")
+			cmd = exec.Command("kubectl", "get", "version", scanVersionName,
+				"-n", namespace,
+				"-o", "jsonpath={.status.sourceScan.findings}",
+			)
+			findings, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(findings).To(ContainSubstring("AVD-"),
+				"expected sourceScan.findings to contain at least one AVD- rule ID")
+		})
+	})
 })


### PR DESCRIPTION
This pull request introduces significant improvements to OpenDepot's storage and controller subsystems, focusing on efficient artifact handling, improved concurrency control, and enhanced documentation. The most notable changes are the addition of streaming support for large provider artifacts, the introduction of semaphores to prevent resource exhaustion, and improved error handling and logging in the version controller.

**Artifact Streaming and Storage Backend Enhancements**
* Added `FileReader` (an `io.ReadSeeker`) to `StorageObjectInput` in `pkg/storage/types/types.go`, allowing storage backends to stream large artifacts directly from disk instead of loading them fully into memory. All storage backends (`aws.go`, `azure.go`, `filesystem.go`, `gcp.go`) now use `FileReader` when available, reducing Go heap usage and risk of OOM kills. [[1]](diffhunk://#diff-f54f442b084cac1e0923b4076b6630dce4dffb4a34e752cb29a3f30a8af37628L22-R29) [[2]](diffhunk://#diff-649bd058ff30ffa9dc08e4ec15730d83af0e6f2428a29290eae2760dc6d10eabR96-R108) [[3]](diffhunk://#diff-b9fbe1068a5da2e483f6139ff5458c1b692407824ab238edf349f98ad45e9033R109-R119) [[4]](diffhunk://#diff-8391eed3da0f9f654c7a6caf5223726af970e8c15fd3e3d6e3abb59e57e8854bL61-R72) [[5]](diffhunk://#diff-8391eed3da0f9f654c7a6caf5223726af970e8c15fd3e3d6e3abb59e57e8854bL100-R118) [[6]](diffhunk://#diff-2d77f98f043eb359cb1ff8d6d46990e8de27788ba3ee35f795083aee9ec5ba82R116-R126)

**Controller Concurrency and Fast-Path Optimization**
* Introduced `scanSem` and `downloadSem` semaphores in the `VersionReconciler` to limit concurrent Trivy scans and provider archive downloads, preventing resource exhaustion in container environments. Provider downloads and scans are now serialized, and controller logs are more verbose for easier debugging. [[1]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cR66-R73) [[2]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cL162-R329) [[3]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cR354-R366) [[4]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cR379-R384)
* Implemented a fast-path for provider artifacts: if an artifact is already present in storage and the checksum matches, the controller skips the download and upload steps, saving memory and I/O.

**Controller Error Handling and Logging Improvements**
* Improved error handling for mutually exclusive `moduleConfigRef` and `providerConfigRef` fields: the controller now writes a terminal status and avoids unnecessary requeues or error logs. Additional logging added throughout the reconciliation flow for better traceability. [[1]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cR136-R164) [[2]](diffhunk://#diff-8c52c08b561691df615c232b4c532137e620cf83a029d28b82c9cc8854fa760cL162-R329)

**Documentation Updates**
* Added documentation for inline module configuration, explaining how to create self-contained `Version` CRs without a corresponding `Module` CR.

**Resource Configuration**
* Increased the default memory limit for the OpenDepot Helm chart from 512Mi to 4Gi to accommodate larger artifacts and scanning workloads.

These changes collectively make OpenDepot more robust and scalable, especially when handling large provider artifacts in resource-constrained environments.