### PR TITLE
Ensure we use appVersion from chart so we don't have to update the va…

### DIFF
--- a/chart/opendepot/templates/depot-deployment.yaml
+++ b/chart/opendepot/templates/depot-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 65532
       containers:
       - name: depot-controller
-        image: "{{ .Values.depot.image.repository }}:{{ default .Values.global.image.tag .Values.depot.image.tag }}"
+        image: "{{ .Values.depot.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.depot.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if .Values.rbac.scopeToNamespace }}
         env:

--- a/chart/opendepot/templates/module-deployment.yaml
+++ b/chart/opendepot/templates/module-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 65532
       containers:
       - name: deployment-controller
-        image: "{{ .Values.module.image.repository }}:{{ default .Values.global.image.tag .Values.module.image.tag }}"
+        image: "{{ .Values.module.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.module.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if .Values.rbac.scopeToNamespace }}
         env:

--- a/chart/opendepot/templates/provider-deployment.yaml
+++ b/chart/opendepot/templates/provider-deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsUser: 65532
       containers:
       - name: provider-controller
-        image: "{{ .Values.provider.image.repository }}:{{ default .Values.global.image.tag .Values.provider.image.tag }}"
+        image: "{{ .Values.provider.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.provider.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if .Values.rbac.scopeToNamespace }}
         env:

--- a/chart/opendepot/templates/server-deployment.yaml
+++ b/chart/opendepot/templates/server-deployment.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       containers:
       - name: server
-        image: "{{ .Values.server.image.repository }}:{{ default .Values.global.image.tag .Values.server.image.tag }}"
+        image: "{{ .Values.server.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.server.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         args:
         {{- if .Values.server.anonymousAuth }}

--- a/chart/opendepot/templates/version-deployment.yaml
+++ b/chart/opendepot/templates/version-deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: version-controller
-        image: "{{ .Values.version.image.repository }}:{{ default .Values.global.image.tag .Values.version.image.tag }}"
+        image: "{{ .Values.version.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.version.image.tag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if or .Values.scanning.enabled .Values.version.zapLogLevel }}
         args:

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -7,7 +7,7 @@ global:
   namespace: opendepot-system
   imagePullPolicy: IfNotPresent
   image:
-    tag: 0.2.3
+    tag: ""  # Defaults to Chart.AppVersion when empty
 
 ## Version Service (Core - handles GitHub fetching and storage)
 version:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  🚀 <strong>OpenDepot v0.2.3</strong> is now available &mdash;
+  🚀 <strong>OpenDepot v0.2.4</strong> is now available &mdash;
   <a href="https://github.com/tonedefdev/opendepot/releases" target="_blank" rel="noopener">
     Release notes &nbsp;→
   </a>


### PR DESCRIPTION
This pull request updates the default image tag handling in the OpenDepot Helm chart templates to improve version management and make the deployment process more robust. The main change is to ensure that, if no image tag is specified, the chart’s `AppVersion` is used by default. Additionally, the documentation and announcement banner have been updated to reflect the new release version.

**Helm chart template improvements:**

* Updated all controller and server deployment templates (`depot-deployment.yaml`, `module-deployment.yaml`, `provider-deployment.yaml`, `server-deployment.yaml`, `version-deployment.yaml`) to use a nested `default` function so that, if no image tag is set, the chart’s `AppVersion` is used as the image tag. This ensures deployments are always versioned consistently, even if the global image tag is not specified. [[1]](diffhunk://#diff-02f1dac3ba6e8a67ffcb591b68a7f50888b6b66f0b76b41f743ebd3ec8120e25L28-R28) [[2]](diffhunk://#diff-6350fc0b03679d838b626926af8bf7a76493ba6a2af83cd096f79615e7c17704L28-R28) [[3]](diffhunk://#diff-b1979c7901ba7cc12a82d8facd345f9285a86c0d399a29a913e7da34d9d8345eL28-R28) [[4]](diffhunk://#diff-18c344aae20b920d35bb7a2cc9d5f66aa116275828ab91b5ee48403e499edb6bL41-R41) [[5]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L44-R44)

* Changed the default value of `global.image.tag` in `values.yaml` to an empty string, clarifying that it will default to `Chart.AppVersion` when not set.

**Documentation and announcement updates:**

* Updated the release announcement banner in `main.html` to show the new version `v0.2.4`.