### PR TITLE
feat: Split module scanning and trivy into separate images

### DIFF
--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -74,7 +74,7 @@ Follow these patterns exactly as they exist in the codebase:
 - CRD types live in `api/v1alpha1/` — never define new types elsewhere
 - Storage backends are in `pkg/storage/`
 - GitHub integration is in `pkg/github/`
-- Test utilities are in `pkg/testutils/`
+- Test utilities are in `pkg/testutils/` — all shared e2e helpers (`NeedsRebuild`, `ComputeBuildContextHash`, `SplitImageRef`, etc.) MUST live here; never duplicate them per-suite
 
 **Testing**:
 - Tests use Ginkgo v2 (`Describe`, `Context`, `It`, `BeforeEach`, `AfterEach`)

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Use when: planning a new feature, designing a change, creating a spec, gathering requirements, breaking down work, clarifying scope, or starting implementation of anything in the OpenDepot project. Produces a structured implementation plan saved to session memory for the developer agent."
 name: "OpenDepot Planner"
-tools: [read, edit, agent, todo]
+tools: [read, edit, search, web, vscode/memory]
 argument-hint: "Describe the feature or change you want to implement"
 ---
 

--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -1,7 +1,7 @@
 ---
 description: "Use when: planning a new feature, designing a change, creating a spec, gathering requirements, breaking down work, clarifying scope, or starting implementation of anything in the OpenDepot project. Produces a structured implementation plan saved to session memory for the developer agent."
 name: "OpenDepot Planner"
-tools: [read, edit, search, web, vscode/memory]
+tools: [read, search, web, vscode/memory]
 argument-hint: "Describe the feature or change you want to implement"
 ---
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,14 +17,28 @@ jobs:
         service:
           - name: version-controller
             path: services/version
+            buildArgs: ""
+            tagSuffix: ""
+          - name: version-controller
+            path: services/version
+            buildArgs: "INCLUDE_TRIVY=true"
+            tagSuffix: "-scanning"
           - name: module-controller
             path: services/module
+            buildArgs: ""
+            tagSuffix: ""
           - name: depot-controller
             path: services/depot
+            buildArgs: ""
+            tagSuffix: ""
           - name: server
             path: services/server
+            buildArgs: ""
+            tagSuffix: ""
           - name: provider-controller
             path: services/provider
+            buildArgs: ""
+            tagSuffix: ""
         arch:
           - amd64
           - arm64
@@ -51,7 +65,7 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.service.name }}
           flavor: |
-            suffix=-${{ matrix.arch }}
+            suffix=-${{ matrix.arch }}${{ matrix.service.tagSuffix }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -68,6 +82,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: ${{ matrix.service.buildArgs }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -78,17 +93,19 @@ jobs:
       matrix:
         service:
           - name: version-controller
-            path: services/version
+            tagSuffix: ""
+          - name: version-controller
+            tagSuffix: "-scanning"
           - name: module-controller
-            path: services/module
+            tagSuffix: ""
           - name: depot-controller
-            path: services/depot
+            tagSuffix: ""
           - name: server
-            path: services/server
+            tagSuffix: ""
           - name: provider-controller
-            path: services/provider
+            tagSuffix: ""
 
-    name: Manifest ${{ matrix.service.name }}
+    name: Manifest ${{ matrix.service.name }}${{ matrix.service.tagSuffix }}
 
     steps:
       - name: Log in to GitHub Container Registry
@@ -103,6 +120,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{ github.repository }}/${{ matrix.service.name }}
+          flavor: |
+            suffix=${{ matrix.service.tagSuffix }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -112,11 +131,20 @@ jobs:
 
       - name: Create and push multi-arch manifest
         run: |
-          IMAGE="ghcr.io/${{ github.repository }}/${{ matrix.service.name }}"
+          SUFFIX="${{ matrix.service.tagSuffix }}"
           for TAG in $(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ' '); do
-            docker buildx imagetools create -t "${TAG}" \
-              "${TAG}-amd64" \
-              "${TAG}-arm64" || true
+            if [ -n "$SUFFIX" ]; then
+              # Build job produced tags like: 0.2.7-amd64-scanning
+              # Strip the tagSuffix from the end of TAG to get the base, then append arch+suffix
+              BASE="${TAG%$SUFFIX}"
+              docker buildx imagetools create -t "${TAG}" \
+                "${BASE}-amd64${SUFFIX}" \
+                "${BASE}-arm64${SUFFIX}" || true
+            else
+              docker buildx imagetools create -t "${TAG}" \
+                "${TAG}-amd64" \
+                "${TAG}-arm64" || true
+            fi
           done
 
   build-status:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -102,9 +102,11 @@ jobs:
         run: |
           docker pull ${{ env.REGISTRY }}/module-controller:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }}
+          docker pull ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }}
           docker tag ${{ env.REGISTRY }}/module-controller:${{ env.IMAGE_TAG }} module-controller:e2e-test
           docker tag ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }} version-controller:e2e-test
+          docker tag ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }} version-controller:e2e-test-scanning
           docker tag ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }} server:e2e-test
 
       - name: Install kind
@@ -127,7 +129,7 @@ jobs:
 
       - name: Run module e2e tests
         working-directory: services/module
-        run: KIND_CLUSTER=opendepot-test-e2e IMG=module-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 20m
+        run: SKIP_IMAGE_BUILD=true KIND_CLUSTER=opendepot-test-e2e IMG=module-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 20m
 
   e2e-provider:
     name: Provider controller e2e
@@ -159,9 +161,11 @@ jobs:
         run: |
           docker pull ${{ env.REGISTRY }}/provider-controller:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }}
+          docker pull ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }}
           docker tag ${{ env.REGISTRY }}/provider-controller:${{ env.IMAGE_TAG }} provider-controller:e2e-test
           docker tag ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }} version-controller:e2e-test
+          docker tag ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }} version-controller:e2e-test-scanning
           docker tag ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }} server:e2e-test
 
       - name: Install kind
@@ -184,7 +188,7 @@ jobs:
 
       - name: Run provider e2e tests
         working-directory: services/provider
-        run: KIND_CLUSTER=opendepot-test-e2e IMG=provider-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 30m
+        run: SKIP_IMAGE_BUILD=true KIND_CLUSTER=opendepot-test-e2e IMG=provider-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 30m
 
   e2e-depot:
     name: Depot controller e2e
@@ -323,7 +327,7 @@ jobs:
           docker pull ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }}
           docker tag ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }} version-controller:e2e-test
-          docker tag ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }} version-controller-scanning:e2e-test
+          docker tag ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }} version-controller:e2e-test-scanning
           docker tag ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }} server:e2e-test
 
       - name: Install kind
@@ -341,4 +345,4 @@ jobs:
 
       - name: Run version e2e tests
         working-directory: services/version
-        run: KIND_CLUSTER=opendepot-test-e2e IMG=version-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 20m
+        run: SKIP_IMAGE_BUILD=true KIND_CLUSTER=opendepot-test-e2e IMG=version-controller:e2e-test go test ./test/e2e/ -v -ginkgo.v -count=1 -timeout 20m

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,14 +31,22 @@ jobs:
         include:
           - service: depot-controller
             dockerfile: services/depot/Dockerfile
+            buildArgs: ""
           - service: module-controller
             dockerfile: services/module/Dockerfile
+            buildArgs: ""
           - service: provider-controller
             dockerfile: services/provider/Dockerfile
+            buildArgs: ""
           - service: server
             dockerfile: services/server/Dockerfile
+            buildArgs: ""
           - service: version-controller
             dockerfile: services/version/Dockerfile
+            buildArgs: ""
+          - service: version-controller-scanning
+            dockerfile: services/version/Dockerfile
+            buildArgs: "INCLUDE_TRIVY=true"
 
     steps:
       - uses: actions/checkout@v4
@@ -60,6 +68,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ matrix.service }}:${{ env.IMAGE_TAG }}
+          build-args: ${{ matrix.buildArgs }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
@@ -311,8 +320,10 @@ jobs:
       - name: Pull e2e images
         run: |
           docker pull ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }}
+          docker pull ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }}
           docker pull ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }}
           docker tag ${{ env.REGISTRY }}/version-controller:${{ env.IMAGE_TAG }} version-controller:e2e-test
+          docker tag ${{ env.REGISTRY }}/version-controller-scanning:${{ env.IMAGE_TAG }} version-controller-scanning:e2e-test
           docker tag ${{ env.REGISTRY }}/server:${{ env.IMAGE_TAG }} server:e2e-test
 
       - name: Install kind

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
-[![Helm](https://img.shields.io/badge/Helm_Chart-0.2.7-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
+[![Helm](https://img.shields.io/badge/Helm_Chart-0.3.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
 [![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
 
 <p align="center">

--- a/chart/opendepot/Chart.yaml
+++ b/chart/opendepot/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: opendepot
 description: A Helm chart for deploying OpenDepot, a cloud-native OpenTofu Registry
 type: application
-version: 0.2.7
+version: 0.2.8
 appVersion: "0.2.7"
 keywords:
   - terraform

--- a/chart/opendepot/Chart.yaml
+++ b/chart/opendepot/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opendepot
 description: A Helm chart for deploying OpenDepot, a cloud-native OpenTofu Registry
 type: application
-version: 0.2.8
-appVersion: "0.2.7"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - terraform
   - opentofu

--- a/chart/opendepot/templates/scanning-cronjob.yaml
+++ b/chart/opendepot/templates/scanning-cronjob.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scanning.enabled }}
+{{- if and .Values.scanning.enabled .Values.scanning.providerScanning }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/chart/opendepot/templates/scanning-pvc.yaml
+++ b/chart/opendepot/templates/scanning-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.scanning.enabled }}
+{{- if and .Values.scanning.enabled .Values.scanning.providerScanning }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/chart/opendepot/templates/version-deployment.yaml
+++ b/chart/opendepot/templates/version-deployment.yaml
@@ -41,17 +41,21 @@ spec:
       {{- end }}
       containers:
       - name: version-controller
-        image: "{{ .Values.version.image.repository }}:{{ default (default .Chart.AppVersion .Values.global.image.tag) .Values.version.image.tag }}"
+        {{- $tag := default (default .Chart.AppVersion .Values.global.image.tag) .Values.version.image.tag }}
+        {{- $imageTag := ternary (printf "%s-scanning" $tag) $tag .Values.scanning.enabled }}
+        image: "{{ .Values.version.image.repository }}:{{ $imageTag }}"
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         {{- if or .Values.scanning.enabled .Values.version.zapLogLevel }}
         args:
         {{- if .Values.scanning.enabled }}
         - --scanning-enabled=true
-        - --trivy-cache-dir={{ .Values.scanning.cacheMountPath }}
-        - --scan-offline={{ .Values.scanning.offline }}
         - --scan-block-on-critical={{ .Values.scanning.blockOnCritical }}
         - --scan-block-on-high={{ .Values.scanning.blockOnHigh }}
-        - --scan-modules={{ .Values.scanning.scanModules }}
+        - --scan-modules=true
+        {{- if .Values.scanning.providerScanning }}
+        - --trivy-cache-dir={{ .Values.scanning.cacheMountPath }}
+        - --scan-offline={{ .Values.scanning.offline }}
+        {{- end }}
         {{- end }}
         {{- if .Values.version.zapLogLevel }}
         - --zap-log-level={{ .Values.version.zapLogLevel }}
@@ -69,18 +73,18 @@ spec:
           {{- end }}
         resources:
           {{- toYaml .Values.version.resources | nindent 10 }}
-        {{- if or .Values.storage.filesystem.enabled .Values.scanning.enabled }}
+        {{- if or .Values.storage.filesystem.enabled .Values.scanning.providerScanning }}
         volumeMounts:
         {{- if .Values.storage.filesystem.enabled }}
         - name: modules
           mountPath: {{ .Values.storage.filesystem.mountPath }}
         {{- end }}
-        {{- if .Values.scanning.enabled }}
+        {{- if .Values.scanning.providerScanning }}
         - name: trivy-cache
           mountPath: {{ .Values.scanning.cacheMountPath }}
         {{- end }}
         {{- end }}
-      {{- if or .Values.storage.filesystem.enabled .Values.scanning.enabled }}
+      {{- if or .Values.storage.filesystem.enabled .Values.scanning.providerScanning }}
       volumes:
       {{- if .Values.storage.filesystem.enabled }}
       - name: modules
@@ -93,7 +97,7 @@ spec:
           claimName: opendepot-modules
         {{- end }}
       {{- end }}
-      {{- if .Values.scanning.enabled }}
+      {{- if .Values.scanning.providerScanning }}
       - name: trivy-cache
         persistentVolumeClaim:
           claimName: opendepot-trivy-cache

--- a/chart/opendepot/values.yaml
+++ b/chart/opendepot/values.yaml
@@ -159,23 +159,29 @@ storage:
     # Size of the PersistentVolumeClaim (ignored when hostPath is set)
     size: 10Gi
 
-## Scanning configuration (Trivy-based provider vulnerability scanning)
+## Scanning configuration (Trivy-based vulnerability and IaC scanning)
 scanning:
-  # Enable Trivy security scanning for provider artifacts
+  # Enable Trivy-based scanning. When true, the version-controller automatically
+  # uses the image variant tagged with the -scanning suffix, which bundles the
+  # Trivy binary. Module IaC scanning (HCL misconfiguration detection) is active
+  # at this level — no PVC or CronJob infrastructure is required.
   enabled: false
-  # Mount path inside the version-controller container for the Trivy DB cache
+  # Enable provider binary and source scanning. Requires scanning.enabled=true.
+  # When true, creates the Trivy vulnerability DB PVC and the trivy-db-updater
+  # CronJob, and mounts the cache volume into the version-controller.
+  providerScanning: false
+  # Mount path inside the version-controller container for the Trivy DB cache.
+  # Only used when providerScanning is true.
   cacheMountPath: /var/cache/trivy
   # Pass --offline-scan to Trivy, preventing network calls during scans.
-  # Set to false only when you want Trivy to download the DB at scan time instead of
-  # relying on the pre-populated cache from the trivy-db-updater CronJob.
+  # Only relevant when providerScanning is true.
   offline: true
-  # Block provider reconciliation when CRITICAL vulnerabilities are found
+  # Block reconciliation when CRITICAL vulnerabilities are found (modules or providers).
   blockOnCritical: false
-  # Block provider reconciliation when HIGH vulnerabilities are found
+  # Block reconciliation when HIGH vulnerabilities are found (modules or providers).
   blockOnHigh: false
-  # Enable Trivy IaC scanning for module version archives (requires scanning.enabled=true)
-  scanModules: false
-  # PersistentVolumeClaim for the shared Trivy vulnerability database
+  # PersistentVolumeClaim for the shared Trivy vulnerability database.
+  # Only created when providerScanning is true.
   cache:
     # StorageClass must support ReadWriteMany so that scanner and updater pods can share it.
     # For single-node environments (e.g. Kind), ReadWriteOnce with the default storage class works.
@@ -185,7 +191,8 @@ scanning:
     accessMode: ReadWriteMany
     # Size of the Trivy DB cache PVC
     size: 1Gi
-  # CronJob that runs 'trivy image --download-db-only' daily to keep the offline DB current
+  # CronJob that runs 'trivy image --download-db-only' on a schedule to keep the offline DB current.
+  # Only created when providerScanning is true.
   dbUpdater:
     # Cron schedule for the Trivy DB update job (default: 02:00 UTC daily)
     schedule: "0 2 * * *"

--- a/docs/configuration/scanning.md
+++ b/docs/configuration/scanning.md
@@ -197,12 +197,12 @@ See [GitHub Authentication](github-auth.md) for instructions on creating the `op
 
 | Value | Default | Description |
 |---|---|---|
-| `scanning.enabled` | `false` | Enable Trivy vulnerability scanning for provider artifacts and module IaC |
+| `scanning.enabled` | `false` | Enable Trivy-based scanning. Switches the version-controller to the `-scanning` image variant and activates module IaC scanning. No PVC or CronJob is created at this level |
+| `scanning.providerScanning` | `false` | Enable provider binary and source scanning. Requires `scanning.enabled=true`. Creates the Trivy DB PVC and `trivy-db-updater` CronJob and mounts the cache volume |
 | `scanning.cacheMountPath` | `/var/cache/trivy` | Mount path inside the version-controller container for the Trivy DB cache |
-| `scanning.offline` | `true` | Pass `--offline-scan` to Trivy. Prevents network calls during scans |
-| `scanning.blockOnCritical` | `false` | Halt provider reconciliation when CRITICAL findings are present |
-| `scanning.blockOnHigh` | `false` | Halt provider reconciliation when HIGH findings are present |
-| `scanning.scanModules` | `false` | Enable Trivy IaC scanning for module version archives (requires `scanning.enabled=true`) |
+| `scanning.offline` | `true` | Pass `--offline-scan` to Trivy. Prevents network calls during scans. Only applies to provider scanning |
+| `scanning.blockOnCritical` | `false` | Halt reconciliation when CRITICAL findings are present (modules or providers) |
+| `scanning.blockOnHigh` | `false` | Halt reconciliation when HIGH findings are present (modules or providers) |
 | `scanning.cache.storageClassName` | `""` | StorageClass for the Trivy cache PVC (must support ReadWriteMany for multi-node). Omitted from the PVC manifest when blank, allowing the cluster default to apply stably across upgrades |
 | `scanning.cache.accessMode` | `ReadWriteMany` | Access mode for the Trivy cache PVC |
 | `scanning.cache.size` | `1Gi` | Size of the Trivy DB cache PVC |

--- a/docs/configuration/scanning.md
+++ b/docs/configuration/scanning.md
@@ -10,7 +10,10 @@ tags:
 
 # Vulnerability Scanning
 
-OpenDepot integrates [Trivy](https://trivy.dev/) to scan both provider artifacts and module archives. When enabled, the Version controller runs scans automatically during reconciliation and stores findings directly on the Kubernetes resources.
+OpenDepot integrates [Trivy](https://trivy.dev/) to scan both provider artifacts and module archives. Scanning is split into two tiers:
+
+- **Module IaC scanning** — enabled by `scanning.enabled: true`. Detects HCL misconfigurations in module archives using Trivy's bundled config rules. Requires no external infrastructure. Setting this flag automatically switches the version-controller to the `-scanning` image variant, which bundles the Trivy binary.
+- **Provider scanning** — enabled by `scanning.providerScanning: true` (requires `scanning.enabled: true`). Scans provider binaries and source dependencies against the Trivy vulnerability database. Requires a shared PersistentVolumeClaim and a CronJob to keep the database current.
 
 ## Provider Scanning
 
@@ -39,25 +42,48 @@ For each module version, the Version controller runs an IaC scan on the extracte
 
 Findings are stored in `Version.status.sourceScan` and use the same `SecurityFinding` struct as provider scans. The `vulnerabilityID` field contains a Trivy rule ID (e.g. `AVD-AWS-0057`) rather than a CVE identifier.
 
-!!! note
-    Module IaC scanning does **not** require the Trivy vulnerability database (the CronJob or PVC). Config-class rules are bundled in the Trivy binary itself. You can enable module scanning without setting up the DB infrastructure.
-
 See [Consuming Modules](../guides/modules.md#vulnerability-scanning) for examples of reading scan results.
+
+## Scanning Image Variant
+
+When `scanning.enabled: true`, the Helm chart automatically selects the version-controller image tagged with the `-scanning` suffix (e.g. `0.2.7-scanning`). This variant is built from the same Dockerfile as the standard image using the `INCLUDE_TRIVY=true` build argument, which copies the Trivy binary into the final image. The standard image (`0.2.7`) does not include Trivy, keeping it lean for installations that do not require any scanning.
 
 ## Prerequisites
 
-Scanning requires a shared PersistentVolumeClaim for the Trivy vulnerability database and a CronJob that keeps it up to date. Both are created automatically when `scanning.enabled` is set to `true`.
+Provider scanning requires a shared PersistentVolumeClaim for the Trivy vulnerability database and a CronJob that keeps it up to date. Both are created automatically when `scanning.providerScanning` is set to `true`.
 
 The PVC must use a `StorageClass` that supports `ReadWriteMany` access so that the `trivy-db-updater` CronJob and the version-controller pod can mount it simultaneously. For single-node environments such as Kind, `ReadWriteOnce` with the default storage class is sufficient.
 
 !!! note
-    The Trivy DB (PVC + CronJob) is only required for **provider** binary and source scans. Module IaC scanning uses config rules bundled in the Trivy binary and works without a populated DB cache.
+    The Trivy DB (PVC + CronJob) is only required for provider binary and source scans. Module IaC scanning uses config rules bundled in the Trivy binary and works without any DB infrastructure — just set `scanning.enabled: true`.
 
-## Enabling Scanning
+## Enabling Module IaC Scanning
+
+To enable lightweight module scanning with no additional infrastructure:
 
 ```yaml
 scanning:
   enabled: true
+  blockOnCritical: false
+  blockOnHigh: false
+```
+
+Apply via Helm upgrade:
+
+```bash
+helm upgrade opendepot opendepot/opendepot \
+  --namespace opendepot-system \
+  --set scanning.enabled=true
+```
+
+## Enabling Provider Scanning
+
+To enable full provider binary and source scanning alongside module IaC scanning:
+
+```yaml
+scanning:
+  enabled: true
+  providerScanning: true
   blockOnCritical: false
   blockOnHigh: false
   cache:
@@ -72,6 +98,7 @@ Apply via Helm upgrade:
 helm upgrade opendepot opendepot/opendepot \
   --namespace opendepot-system \
   --set scanning.enabled=true \
+  --set scanning.providerScanning=true \
   --set scanning.cache.storageClassName=efs-sc
 ```
 
@@ -91,13 +118,16 @@ scanning:
 
 ## Offline Mode
 
-By default, scanning runs in offline mode (`scanning.offline: true`). Trivy reads the vulnerability database from the shared PVC populated by the `trivy-db-updater` CronJob and makes no outbound network calls during a scan. This is the recommended configuration for production clusters.
+By default, provider scanning runs in offline mode (`scanning.offline: true`). Trivy reads the vulnerability database from the shared PVC populated by the `trivy-db-updater` CronJob and makes no outbound network calls during a scan. This is the recommended configuration for production clusters.
 
 Set `scanning.offline: false` only if you want Trivy to download the database directly at scan time instead of relying on the CronJob. This requires the version-controller pod to have egress access to `ghcr.io`.
 
+!!! note
+    `scanning.offline` only applies to provider scanning. Module IaC scanning uses bundled config rules and makes no network calls regardless of this setting.
+
 ## Trivy DB Updater CronJob
 
-The `trivy-db-updater` CronJob runs `trivy image --download-db-only` on a schedule to refresh the local vulnerability database cache. By default it runs daily at 02:00 UTC.
+The `trivy-db-updater` CronJob runs `trivy image --download-db-only` on a schedule to refresh the local vulnerability database cache. It is only created when `scanning.providerScanning: true`. By default it runs daily at 02:00 UTC.
 
 ```yaml
 scanning:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -366,21 +366,21 @@ This step shows Trivy scanning in action against the module from Step 4 and, if 
 
 **Step 9a: Enable scanning**
 
-Kind uses a single-node cluster, so `ReadWriteOnce` access mode and the default storage class are sufficient. Set `offline=false` so Trivy downloads the vulnerability database directly rather than waiting for the CronJob to complete on a fresh cluster:
+Setting `scanning.enabled=true` activates module IaC scanning with no additional infrastructure — the version-controller automatically uses the `-scanning` image variant. To also enable provider binary and source scanning (which needs the Trivy DB PVC and CronJob), set `scanning.providerScanning=true`. Kind uses a single-node cluster, so `ReadWriteOnce` access mode and the default storage class are sufficient. Set `offline=false` so Trivy downloads the vulnerability database directly rather than waiting for the CronJob to complete on a fresh cluster:
 
 ```bash
 helm upgrade opendepot opendepot/opendepot \
   -n opendepot-system \
   --reuse-values \
   --set scanning.enabled=true \
+  --set scanning.providerScanning=true \
   --set scanning.offline=false \
   --set scanning.cache.accessMode=ReadWriteOnce \
-  --set scanning.scanModules=true \
   --wait
 ```
 
 !!! note
-    `scanning.offline=false` is a convenience for local development. In production, leave `offline=true` (the default) and rely on the `trivy-db-updater` CronJob to keep the database current.
+    `scanning.offline=false` is a convenience for local development. In production, leave `offline=true` (the default) and rely on the `trivy-db-updater` CronJob to keep the database current. `scanning.offline` only applies to provider scanning — module IaC scanning uses bundled config rules and makes no network calls.
 
 **Step 9b: Trigger a module scan**
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  🚀 <strong>OpenDepot v0.2.7</strong> is now available &mdash;
+  🚀 <strong>OpenDepot v0.3.0</strong> is now available &mdash;
   <a href="https://github.com/tonedefdev/opendepot/releases" target="_blank" rel="noopener">
     Release notes &nbsp;→
   </a>

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -20,6 +20,7 @@ limitations under the License.
 package testutils
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
@@ -181,4 +182,51 @@ func IsPrometheusCRDsInstalled() bool {
 		}
 	}
 	return false
+}
+
+// NeedsRebuild returns true if the image is absent or its opendepot.build.hash
+// label does not match wantHash.
+func NeedsRebuild(image, wantHash string) bool {
+	out, err := exec.Command(
+		"docker", "inspect",
+		"--format", `{{ index .Config.Labels "opendepot.build.hash" }}`,
+		image,
+	).Output()
+	if err != nil {
+		return true // image absent
+	}
+	return strings.TrimSpace(string(out)) != wantHash
+}
+
+// ComputeBuildContextHash computes a SHA-256 hash over the contents of all
+// git-tracked files under the given paths (relative to repoRoot). This
+// produces a deterministic fingerprint of the Docker build context without
+// requiring a build.
+func ComputeBuildContextHash(repoRoot string, paths []string) (string, error) {
+	args := append([]string{"-C", repoRoot, "ls-files", "--"}, paths...)
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-files: %w", err)
+	}
+	h := sha256.New()
+	for rel := range strings.FieldsSeq(string(out)) {
+		data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", rel, err)
+		}
+		fmt.Fprintf(h, "%s\n", rel)
+		h.Write(data)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))[:16], nil
+}
+
+// SplitImageRef splits an image reference "repo:tag" into its components.
+// If no tag is present, "latest" is returned as the tag.
+func SplitImageRef(ref string) (repo, tag string) {
+	for i := len(ref) - 1; i >= 0; i-- {
+		if ref[i] == ':' {
+			return ref[:i], ref[i+1:]
+		}
+	}
+	return ref, "latest"
 }

--- a/services/depot/test/e2e/e2e_suite_test.go
+++ b/services/depot/test/e2e/e2e_suite_test.go
@@ -129,9 +129,9 @@ var _ = BeforeSuite(func() {
 	chartPath, err := utils.GetChartPath()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	depotRepo, depotTag := splitImageRef(projectImage)
-	versionRepo, versionTag := splitImageRef(versionImage)
-	serverRepo, serverTag := splitImageRef(serverImage)
+	depotRepo, depotTag := utils.SplitImageRef(projectImage)
+	versionRepo, versionTag := utils.SplitImageRef(versionImage)
+	serverRepo, serverTag := utils.SplitImageRef(serverImage)
 
 	cmd = exec.Command("helm", "upgrade", helmReleaseName, chartPath,
 		"--install",
@@ -168,13 +168,4 @@ var _ = AfterSuite(func() {
 	_, _ = utils.Run(cmd)
 })
 
-// splitImageRef splits an image reference "repo:tag" into its components.
-// If no tag is present, "latest" is returned as the tag.
-func splitImageRef(ref string) (repo, tag string) {
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == ':' {
-			return ref[:i], ref[i+1:]
-		}
-	}
-	return ref, "latest"
-}
+

--- a/services/module/test/e2e/e2e_suite_test.go
+++ b/services/module/test/e2e/e2e_suite_test.go
@@ -42,6 +42,11 @@ var (
 	// versionImage is the version controller image to deploy for e2e tests.
 	versionImage = "version-controller:e2e-test"
 
+	// versionScanningImage is the scanning variant of the version controller image
+	// (built with INCLUDE_TRIVY=true). Loaded into Kind so the cluster has it
+	// available if scanning is enabled in any context.
+	versionScanningImage = "version-controller:e2e-test-scanning"
+
 	// serverImage is the server image to deploy for e2e tests.
 	serverImage = "server:e2e-test"
 )
@@ -62,43 +67,92 @@ var _ = BeforeSuite(func() {
 	repoRoot, err := utils.GetRepoRoot()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to determine repo root")
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", projectImage).Output(); inspectErr != nil {
-		By("building the module controller image")
-		buildCmd := exec.Command("docker", "build",
-			"-t", projectImage,
-			"-f", "services/module/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(buildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the module controller image")
-	} else {
-		By("module controller image already present, skipping build")
-	}
+	if os.Getenv("SKIP_IMAGE_BUILD") != "true" {
+		moduleHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/module",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute module controller build hash")
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", versionImage).Output(); inspectErr != nil {
-		By("building the version controller image")
-		versionBuildCmd := exec.Command("docker", "build",
-			"-t", versionImage,
-			"-f", "services/version/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(versionBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
-	} else {
-		By("version controller image already present, skipping build")
-	}
+		if utils.NeedsRebuild(projectImage, moduleHash) {
+			By("building the module controller image (context changed or image absent)")
+			buildCmd := exec.Command("docker", "build",
+				"-t", projectImage,
+				"--label", "opendepot.build.hash="+moduleHash,
+				"-f", "services/module/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(buildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the module controller image")
+		} else {
+			By("module controller image up-to-date, skipping build")
+		}
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", serverImage).Output(); inspectErr != nil {
-		By("building the server image")
-		serverBuildCmd := exec.Command("docker", "build",
-			"-t", serverImage,
-			"-f", "services/server/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(serverBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
+		versionHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/version",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute version controller build hash")
+
+		if utils.NeedsRebuild(versionImage, versionHash) {
+			By("building the version controller image (context changed or image absent)")
+			versionBuildCmd := exec.Command("docker", "build",
+				"-t", versionImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(versionBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
+		} else {
+			By("version controller image up-to-date, skipping build")
+		}
+
+		if utils.NeedsRebuild(versionScanningImage, versionHash) {
+			By("building the version controller scanning image (context changed or image absent)")
+			scanningBuildCmd := exec.Command("docker", "build",
+				"-t", versionScanningImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"--build-arg", "INCLUDE_TRIVY=true",
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(scanningBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller scanning image")
+		} else {
+			By("version controller scanning image up-to-date, skipping build")
+		}
+
+		serverHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/server",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute server build hash")
+
+		if utils.NeedsRebuild(serverImage, serverHash) {
+			By("building the server image (context changed or image absent)")
+			serverBuildCmd := exec.Command("docker", "build",
+				"-t", serverImage,
+				"--label", "opendepot.build.hash="+serverHash,
+				"-f", "services/server/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(serverBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
+		} else {
+			By("server image up-to-date, skipping build")
+		}
 	} else {
-		By("server image already present, skipping build")
+		By("SKIP_IMAGE_BUILD=true: skipping image builds, using pre-built images")
 	}
 
 	By("loading the module controller image on Kind")
@@ -108,6 +162,10 @@ var _ = BeforeSuite(func() {
 	By("loading the version controller image on Kind")
 	err = utils.LoadImageToKindClusterWithName(versionImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller image into Kind")
+
+	By("loading the version controller scanning image on Kind")
+	err = utils.LoadImageToKindClusterWithName(versionScanningImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller scanning image into Kind")
 
 	By("loading the server image on Kind")
 	err = utils.LoadImageToKindClusterWithName(serverImage)
@@ -128,16 +186,15 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	// Parse the repository and tag from each image reference (format: "repo:tag").
-	moduleRepo, moduleTag := splitImageRef(projectImage)
-	versionRepo, versionTag := splitImageRef(versionImage)
-	serverRepo, serverTag := splitImageRef(serverImage)
+	moduleRepo, moduleTag := utils.SplitImageRef(projectImage)
+	versionRepo, versionTag := utils.SplitImageRef(versionImage)
+	serverRepo, serverTag := utils.SplitImageRef(serverImage)
 
 	cmd = exec.Command("helm", "upgrade", helmReleaseName, chartPath,
 		"--install",
 		"--create-namespace",
 		"--namespace", namespace,
 		"--skip-crds",
-		"--set", "global.image.tag=",
 		"--set", "depot.enabled=false",
 		"--set", "provider.enabled=false",
 		"--set", "module.enabled=true",
@@ -167,18 +224,4 @@ var _ = AfterSuite(func() {
 	_, _ = utils.Run(cmd)
 })
 
-// splitImageRef splits an image reference "repo:tag" into its components.
-// If no tag is present, "latest" is returned as the tag.
-func splitImageRef(ref string) (repo, tag string) {
-	lastColon := -1
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == ':' {
-			lastColon = i
-			break
-		}
-	}
-	if lastColon < 0 {
-		return ref, "latest"
-	}
-	return ref[:lastColon], ref[lastColon+1:]
-}
+

--- a/services/provider/test/e2e/e2e_suite_test.go
+++ b/services/provider/test/e2e/e2e_suite_test.go
@@ -42,6 +42,11 @@ var (
 	// versionImage is the version controller image to deploy for e2e tests.
 	versionImage = "version-controller:e2e-test"
 
+	// versionScanningImage is the scanning variant of the version controller image
+	// (built with INCLUDE_TRIVY=true). Loaded into Kind so the cluster has it
+	// available if scanning is enabled in any context.
+	versionScanningImage = "version-controller:e2e-test-scanning"
+
 	// serverImage is the server image to deploy for e2e tests.
 	serverImage = "server:e2e-test"
 
@@ -67,43 +72,92 @@ var _ = BeforeSuite(func() {
 	repoRoot, err := utils.GetRepoRoot()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to determine repo root")
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", projectImage).Output(); inspectErr != nil {
-		By("building the provider controller image")
-		buildCmd := exec.Command("docker", "build",
-			"-t", projectImage,
-			"-f", "services/provider/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(buildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the provider controller image")
-	} else {
-		By("provider controller image already present, skipping build")
-	}
+	if os.Getenv("SKIP_IMAGE_BUILD") != "true" {
+		providerHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/provider",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute provider controller build hash")
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", versionImage).Output(); inspectErr != nil {
-		By("building the version controller image")
-		versionBuildCmd := exec.Command("docker", "build",
-			"-t", versionImage,
-			"-f", "services/version/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(versionBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
-	} else {
-		By("version controller image already present, skipping build")
-	}
+		if utils.NeedsRebuild(projectImage, providerHash) {
+			By("building the provider controller image (context changed or image absent)")
+			buildCmd := exec.Command("docker", "build",
+				"-t", projectImage,
+				"--label", "opendepot.build.hash="+providerHash,
+				"-f", "services/provider/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(buildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the provider controller image")
+		} else {
+			By("provider controller image up-to-date, skipping build")
+		}
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", serverImage).Output(); inspectErr != nil {
-		By("building the server image")
-		serverBuildCmd := exec.Command("docker", "build",
-			"-t", serverImage,
-			"-f", "services/server/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(serverBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
+		versionHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/version",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute version controller build hash")
+
+		if utils.NeedsRebuild(versionImage, versionHash) {
+			By("building the version controller image (context changed or image absent)")
+			versionBuildCmd := exec.Command("docker", "build",
+				"-t", versionImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(versionBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
+		} else {
+			By("version controller image up-to-date, skipping build")
+		}
+
+		if utils.NeedsRebuild(versionScanningImage, versionHash) {
+			By("building the version controller scanning image (context changed or image absent)")
+			scanningBuildCmd := exec.Command("docker", "build",
+				"-t", versionScanningImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"--build-arg", "INCLUDE_TRIVY=true",
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(scanningBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller scanning image")
+		} else {
+			By("version controller scanning image up-to-date, skipping build")
+		}
+
+		serverHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/server",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute server build hash")
+
+		if utils.NeedsRebuild(serverImage, serverHash) {
+			By("building the server image (context changed or image absent)")
+			serverBuildCmd := exec.Command("docker", "build",
+				"-t", serverImage,
+				"--label", "opendepot.build.hash="+serverHash,
+				"-f", "services/server/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(serverBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
+		} else {
+			By("server image up-to-date, skipping build")
+		}
 	} else {
-		By("server image already present, skipping build")
+		By("SKIP_IMAGE_BUILD=true: skipping image builds, using pre-built images")
 	}
 
 	By("loading the provider controller image on Kind")
@@ -113,6 +167,10 @@ var _ = BeforeSuite(func() {
 	By("loading the version controller image on Kind")
 	err = utils.LoadImageToKindClusterWithName(versionImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller image into Kind")
+
+	By("loading the version controller scanning image on Kind")
+	err = utils.LoadImageToKindClusterWithName(versionScanningImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller scanning image into Kind")
 
 	By("loading the server image on Kind")
 	err = utils.LoadImageToKindClusterWithName(serverImage)
@@ -150,16 +208,15 @@ var _ = BeforeSuite(func() {
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	// Parse the repository and tag from projectImage (format: "repo:tag").
-	providerRepo, providerTag := splitImageRef(projectImage)
-	versionRepo, versionTag := splitImageRef(versionImage)
-	serverRepo, serverTag := splitImageRef(serverImage)
+	providerRepo, providerTag := utils.SplitImageRef(projectImage)
+	versionRepo, versionTag := utils.SplitImageRef(versionImage)
+	serverRepo, serverTag := utils.SplitImageRef(serverImage)
 
 	cmd = exec.Command("helm", "upgrade", helmReleaseName, chartPath,
 		"--install",
 		"--create-namespace",
 		"--namespace", namespace,
 		"--skip-crds",
-		"--set", "global.image.tag=",
 		"--set", "depot.enabled=false",
 		"--set", "module.enabled=false",
 		"--set", "provider.enabled=true",
@@ -203,18 +260,4 @@ var _ = AfterSuite(func() {
 	}
 })
 
-// splitImageRef splits an image reference "repo:tag" into its components.
-// If no tag is present, "latest" is returned as the tag.
-func splitImageRef(ref string) (repo, tag string) {
-	lastColon := -1
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == ':' {
-			lastColon = i
-			break
-		}
-	}
-	if lastColon < 0 {
-		return ref, "latest"
-	}
-	return ref[:lastColon], ref[lastColon+1:]
-}
+

--- a/services/server/test/e2e/e2e_suite_test.go
+++ b/services/server/test/e2e/e2e_suite_test.go
@@ -94,14 +94,3 @@ var _ = AfterSuite(func() {
 	)
 	_, _ = utils.Run(cmd)
 })
-
-// splitImageRef splits an image reference "repo:tag" into its components.
-// If no tag is present, "latest" is returned as the tag.
-func splitImageRef(ref string) (repo, tag string) {
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == ':' {
-			return ref[:i], ref[i+1:]
-		}
-	}
-	return ref, "latest"
-}

--- a/services/server/test/e2e/e2e_test.go
+++ b/services/server/test/e2e/e2e_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Server Authentication", Ordered, func() {
 		var err error
 		chartPath, err = utils.GetChartPath()
 		Expect(err).NotTo(HaveOccurred())
-		serverRepo, serverTag = splitImageRef(serverImage)
+		serverRepo, serverTag = utils.SplitImageRef(serverImage)
 	})
 
 	// deployServer runs helm upgrade with a common base configuration plus any

--- a/services/version/Dockerfile
+++ b/services/version/Dockerfile
@@ -1,3 +1,6 @@
+# select final stage via build arg (default: no Trivy)
+ARG INCLUDE_TRIVY=false
+
 # Build the manager binary
 FROM golang:1.25 AS builder
 ARG TARGETOS
@@ -53,6 +56,5 @@ COPY --from=trivy-source /usr/local/bin/trivy /usr/local/bin/trivy
 USER 65532:65532
 ENTRYPOINT ["/version-controller"]
 
-# select final stage via build arg (default: no Trivy)
-ARG INCLUDE_TRIVY=false
+# select which final stage was built
 FROM final-${INCLUDE_TRIVY}

--- a/services/version/Dockerfile
+++ b/services/version/Dockerfile
@@ -35,13 +35,24 @@ COPY services/version/internal/ services/version/internal/
 # Build
 RUN cd services/version && CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o /workspace/version-controller cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+# trivy-source: pulled at build time; only copied into the final image when INCLUDE_TRIVY=true
+FROM aquasec/trivy:0.70.0 AS trivy-source
+
+# final image without Trivy binary
+FROM gcr.io/distroless/static:nonroot AS final-false
 WORKDIR /
 COPY --from=builder /workspace/version-controller .
-# Copy the Trivy binary for optional provider vulnerability scanning
-COPY --from=aquasec/trivy:0.70.0 /usr/local/bin/trivy /usr/local/bin/trivy
 USER 65532:65532
-
 ENTRYPOINT ["/version-controller"]
+
+# final image with Trivy binary bundled
+FROM gcr.io/distroless/static:nonroot AS final-true
+WORKDIR /
+COPY --from=builder /workspace/version-controller .
+COPY --from=trivy-source /usr/local/bin/trivy /usr/local/bin/trivy
+USER 65532:65532
+ENTRYPOINT ["/version-controller"]
+
+# select final stage via build arg (default: no Trivy)
+ARG INCLUDE_TRIVY=false
+FROM final-${INCLUDE_TRIVY}

--- a/services/version/test/e2e/e2e_suite_test.go
+++ b/services/version/test/e2e/e2e_suite_test.go
@@ -171,8 +171,6 @@ var _ = BeforeSuite(func() {
 		"--set", fmt.Sprintf("server.image.tag=%s", serverTag),
 		"--set", "storage.filesystem.enabled=true",
 		"--set", "storage.filesystem.hostPath=/data/modules",
-		"--set", "scanning.enabled=true",
-		"--set", "scanning.cache.accessMode=ReadWriteOnce",
 		"--set", "version.zapLogLevel=5",
 		"--wait",
 		"--timeout", "3m",

--- a/services/version/test/e2e/e2e_suite_test.go
+++ b/services/version/test/e2e/e2e_suite_test.go
@@ -17,12 +17,10 @@ limitations under the License.
 package e2e
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -66,65 +64,69 @@ var _ = BeforeSuite(func() {
 	repoRoot, err := utils.GetRepoRoot()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to determine repo root")
 
-	versionHash, err := computeBuildContextHash(repoRoot, []string{
-		"services/version",
-		"api",
-		"pkg",
-		"go.work",
-		"go.work.sum",
-	})
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute version controller build hash")
+	if os.Getenv("SKIP_IMAGE_BUILD") != "true" {
+		versionHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/version",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute version controller build hash")
 
-	if needsRebuild(projectImage, versionHash) {
-		By("building the version controller image (context changed or image absent)")
-		buildCmd := exec.Command("docker", "build",
-			"-t", projectImage,
-			"--label", "opendepot.build.hash="+versionHash,
-			"-f", "services/version/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(buildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
+		if utils.NeedsRebuild(projectImage, versionHash) {
+			By("building the version controller image (context changed or image absent)")
+			buildCmd := exec.Command("docker", "build",
+				"-t", projectImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(buildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
+		} else {
+			By("version controller image up-to-date, skipping build")
+		}
+
+		if utils.NeedsRebuild(projectScanningImage, versionHash) {
+			By("building the version controller scanning image (context changed or image absent)")
+			scanningBuildCmd := exec.Command("docker", "build",
+				"-t", projectScanningImage,
+				"--label", "opendepot.build.hash="+versionHash,
+				"--build-arg", "INCLUDE_TRIVY=true",
+				"-f", "services/version/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(scanningBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller scanning image")
+		} else {
+			By("version controller scanning image up-to-date, skipping build")
+		}
+
+		serverHash, err := utils.ComputeBuildContextHash(repoRoot, []string{
+			"services/server",
+			"api",
+			"pkg",
+			"go.work",
+			"go.work.sum",
+		})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute server build hash")
+
+		if utils.NeedsRebuild(serverImage, serverHash) {
+			By("building the server image (context changed or image absent)")
+			serverBuildCmd := exec.Command("docker", "build",
+				"-t", serverImage,
+				"--label", "opendepot.build.hash="+serverHash,
+				"-f", "services/server/Dockerfile",
+				".",
+			)
+			_, err = utils.RunAt(serverBuildCmd, repoRoot)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
+		} else {
+			By("server image up-to-date, skipping build")
+		}
 	} else {
-		By("version controller image up-to-date, skipping build")
-	}
-
-	if needsRebuild(projectScanningImage, versionHash) {
-		By("building the version controller scanning image (context changed or image absent)")
-		scanningBuildCmd := exec.Command("docker", "build",
-			"-t", projectScanningImage,
-			"--label", "opendepot.build.hash="+versionHash,
-			"--build-arg", "INCLUDE_TRIVY=true",
-			"-f", "services/version/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(scanningBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller scanning image")
-	} else {
-		By("version controller scanning image up-to-date, skipping build")
-	}
-
-	serverHash, err := computeBuildContextHash(repoRoot, []string{
-		"services/server",
-		"api",
-		"pkg",
-		"go.work",
-		"go.work.sum",
-	})
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute server build hash")
-
-	if needsRebuild(serverImage, serverHash) {
-		By("building the server image (context changed or image absent)")
-		serverBuildCmd := exec.Command("docker", "build",
-			"-t", serverImage,
-			"--label", "opendepot.build.hash="+serverHash,
-			"-f", "services/server/Dockerfile",
-			".",
-		)
-		_, err = utils.RunAt(serverBuildCmd, repoRoot)
-		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
-	} else {
-		By("server image up-to-date, skipping build")
+		By("SKIP_IMAGE_BUILD=true: skipping image builds, using pre-built images")
 	}
 
 	By("loading the version controller image on Kind")
@@ -153,8 +155,8 @@ var _ = BeforeSuite(func() {
 	chartPath, err := utils.GetChartPath()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	versionRepo, versionTag := splitImageRef(projectImage)
-	serverRepo, serverTag := splitImageRef(serverImage)
+	versionRepo, versionTag := utils.SplitImageRef(projectImage)
+	serverRepo, serverTag := utils.SplitImageRef(serverImage)
 
 	cmd = exec.Command("helm", "upgrade", helmReleaseName, chartPath,
 		"--install",
@@ -188,57 +190,4 @@ var _ = AfterSuite(func() {
 	_, _ = utils.Run(cmd)
 })
 
-// needsRebuild returns true if the image is absent or its opendepot.build.hash
-// label does not match wantHash.
-func needsRebuild(image, wantHash string) bool {
-	out, err := exec.Command(
-		"docker", "inspect",
-		"--format", `{{ index .Config.Labels "opendepot.build.hash" }}`,
-		image,
-	).Output()
-	if err != nil {
-		return true // image absent
-	}
-	return strings.TrimSpace(string(out)) != wantHash
-}
 
-// computeBuildContextHash computes a SHA-256 hash over the contents of all
-// git-tracked files under the given paths (relative to repoRoot). This
-// produces a deterministic fingerprint of the Docker build context without
-// requiring a build.
-func computeBuildContextHash(repoRoot string, paths []string) (string, error) {
-	args := append([]string{"-C", repoRoot, "ls-files", "--"}, paths...)
-	out, err := exec.Command("git", args...).Output()
-	if err != nil {
-		return "", fmt.Errorf("git ls-files: %w", err)
-	}
-
-	h := sha256.New()
-	for rel := range strings.FieldsSeq(string(out)) {
-		data, err := os.ReadFile(filepath.Join(repoRoot, rel))
-		if err != nil {
-			return "", fmt.Errorf("read %s: %w", rel, err)
-		}
-
-		fmt.Fprintf(h, "%s\n", rel)
-		h.Write(data)
-	}
-
-	return fmt.Sprintf("%x", h.Sum(nil))[:16], nil
-}
-
-// splitImageRef splits an image reference "repo:tag" into its components.
-// If no tag is present, "latest" is returned as the tag.
-func splitImageRef(ref string) (repo, tag string) {
-	lastColon := -1
-	for i := len(ref) - 1; i >= 0; i-- {
-		if ref[i] == ':' {
-			lastColon = i
-			break
-		}
-	}
-	if lastColon < 0 {
-		return ref, "latest"
-	}
-	return ref[:lastColon], ref[lastColon+1:]
-}

--- a/services/version/test/e2e/e2e_suite_test.go
+++ b/services/version/test/e2e/e2e_suite_test.go
@@ -17,10 +17,12 @@ limitations under the License.
 package e2e
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +40,11 @@ var (
 		}
 		return "version-controller:e2e-test"
 	}()
+
+	// projectScanningImage is the scanning variant of the version controller image
+	// (built with INCLUDE_TRIVY=true). The Helm chart selects this tag automatically
+	// when scanning.enabled=true by appending "-scanning" to the base tag.
+	projectScanningImage = "version-controller:e2e-test-scanning"
 
 	// serverImage is the server image to deploy for e2e tests.
 	serverImage = "server:e2e-test"
@@ -59,35 +66,74 @@ var _ = BeforeSuite(func() {
 	repoRoot, err := utils.GetRepoRoot()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to determine repo root")
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", projectImage).Output(); inspectErr != nil {
-		By("building the version controller image")
+	versionHash, err := computeBuildContextHash(repoRoot, []string{
+		"services/version",
+		"api",
+		"pkg",
+		"go.work",
+		"go.work.sum",
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute version controller build hash")
+
+	if needsRebuild(projectImage, versionHash) {
+		By("building the version controller image (context changed or image absent)")
 		buildCmd := exec.Command("docker", "build",
 			"-t", projectImage,
+			"--label", "opendepot.build.hash="+versionHash,
 			"-f", "services/version/Dockerfile",
 			".",
 		)
 		_, err = utils.RunAt(buildCmd, repoRoot)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller image")
 	} else {
-		By("version controller image already present, skipping build")
+		By("version controller image up-to-date, skipping build")
 	}
 
-	if _, inspectErr := exec.Command("docker", "image", "inspect", serverImage).Output(); inspectErr != nil {
-		By("building the server image")
+	if needsRebuild(projectScanningImage, versionHash) {
+		By("building the version controller scanning image (context changed or image absent)")
+		scanningBuildCmd := exec.Command("docker", "build",
+			"-t", projectScanningImage,
+			"--label", "opendepot.build.hash="+versionHash,
+			"--build-arg", "INCLUDE_TRIVY=true",
+			"-f", "services/version/Dockerfile",
+			".",
+		)
+		_, err = utils.RunAt(scanningBuildCmd, repoRoot)
+		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the version controller scanning image")
+	} else {
+		By("version controller scanning image up-to-date, skipping build")
+	}
+
+	serverHash, err := computeBuildContextHash(repoRoot, []string{
+		"services/server",
+		"api",
+		"pkg",
+		"go.work",
+		"go.work.sum",
+	})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to compute server build hash")
+
+	if needsRebuild(serverImage, serverHash) {
+		By("building the server image (context changed or image absent)")
 		serverBuildCmd := exec.Command("docker", "build",
 			"-t", serverImage,
+			"--label", "opendepot.build.hash="+serverHash,
 			"-f", "services/server/Dockerfile",
 			".",
 		)
 		_, err = utils.RunAt(serverBuildCmd, repoRoot)
 		ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the server image")
 	} else {
-		By("server image already present, skipping build")
+		By("server image up-to-date, skipping build")
 	}
 
 	By("loading the version controller image on Kind")
 	err = utils.LoadImageToKindClusterWithName(projectImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller image into Kind")
+
+	By("loading the version controller scanning image on Kind")
+	err = utils.LoadImageToKindClusterWithName(projectScanningImage)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the version controller scanning image into Kind")
 
 	By("loading the server image on Kind")
 	err = utils.LoadImageToKindClusterWithName(serverImage)
@@ -115,7 +161,6 @@ var _ = BeforeSuite(func() {
 		"--create-namespace",
 		"--namespace", namespace,
 		"--skip-crds",
-		"--set", "global.image.tag=",
 		"--set", "depot.enabled=false",
 		"--set", "provider.enabled=false",
 		"--set", "module.enabled=false",
@@ -127,7 +172,6 @@ var _ = BeforeSuite(func() {
 		"--set", "storage.filesystem.enabled=true",
 		"--set", "storage.filesystem.hostPath=/data/modules",
 		"--set", "scanning.enabled=true",
-		"--set", "scanning.scanModules=true",
 		"--set", "scanning.cache.accessMode=ReadWriteOnce",
 		"--set", "version.zapLogLevel=5",
 		"--wait",
@@ -145,6 +189,45 @@ var _ = AfterSuite(func() {
 	)
 	_, _ = utils.Run(cmd)
 })
+
+// needsRebuild returns true if the image is absent or its opendepot.build.hash
+// label does not match wantHash.
+func needsRebuild(image, wantHash string) bool {
+	out, err := exec.Command(
+		"docker", "inspect",
+		"--format", `{{ index .Config.Labels "opendepot.build.hash" }}`,
+		image,
+	).Output()
+	if err != nil {
+		return true // image absent
+	}
+	return strings.TrimSpace(string(out)) != wantHash
+}
+
+// computeBuildContextHash computes a SHA-256 hash over the contents of all
+// git-tracked files under the given paths (relative to repoRoot). This
+// produces a deterministic fingerprint of the Docker build context without
+// requiring a build.
+func computeBuildContextHash(repoRoot string, paths []string) (string, error) {
+	args := append([]string{"-C", repoRoot, "ls-files", "--"}, paths...)
+	out, err := exec.Command("git", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-files: %w", err)
+	}
+
+	h := sha256.New()
+	for rel := range strings.FieldsSeq(string(out)) {
+		data, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err != nil {
+			return "", fmt.Errorf("read %s: %w", rel, err)
+		}
+
+		fmt.Fprintf(h, "%s\n", rel)
+		h.Write(data)
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))[:16], nil
+}
 
 // splitImageRef splits an image reference "repo:tag" into its components.
 // If no tag is present, "latest" is returned as the tag.

--- a/services/version/test/e2e/e2e_test.go
+++ b/services/version/test/e2e/e2e_test.go
@@ -258,6 +258,75 @@ spec:
 		})
 	})
 
+	Context("Scanning Disabled", Ordered, func() {
+		const (
+			noScanVersionName = "no-scan-s3-bucket-4-3-0"
+			noScanModule      = "terraform-aws-s3-bucket"
+			noScanVersion     = "4.3.0"
+			noScanRepoOwner   = "terraform-aws-modules"
+			noScanRepoURL     = "https://github.com/terraform-aws-modules/terraform-aws-s3-bucket"
+			noScanStorageDir  = "/data/modules"
+		)
+
+		AfterAll(func() {
+			By("removing the no-scan Version CR")
+			cmd := exec.Command("kubectl", "delete", "version", noScanVersionName,
+				"-n", namespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		It("should sync a module Version CR and produce no scan findings when scanning is disabled", func() {
+			By("applying a module Version CR")
+			versionYAML := fmt.Sprintf(`apiVersion: opendepot.defdev.io/v1alpha1
+kind: Version
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  type: Module
+  version: %q
+  moduleConfigRef:
+    name: %q
+    repoOwner: %q
+    repoUrl: %q
+    githubClientConfig:
+      useAuthenticatedClient: false
+    storageConfig:
+      fileSystem:
+        directoryPath: %s
+`, noScanVersionName, namespace, noScanVersion, noScanModule, noScanRepoOwner, noScanRepoURL, noScanStorageDir)
+
+			versionFile := filepath.Join(GinkgoT().TempDir(), "no-scan-version.yaml")
+			Expect(os.WriteFile(versionFile, []byte(versionYAML), 0600)).To(Succeed())
+
+			cmd := exec.Command("kubectl", "apply", "-f", versionFile)
+			_, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred(), "Failed to apply no-scan Version CR")
+
+			By("waiting for the Version CR to reach synced=true")
+			Eventually(func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "version", noScanVersionName,
+					"-n", namespace,
+					"-o", "jsonpath={.status.synced}",
+				)
+				output, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).To(Equal("true"),
+					"expected Version CR to reach synced=true")
+			}, 5*time.Minute, 10*time.Second).Should(Succeed())
+
+			By("asserting that status.sourceScan is absent when scanning is disabled")
+			cmd = exec.Command("kubectl", "get", "version", noScanVersionName,
+				"-n", namespace,
+				"-o", "jsonpath={.status.sourceScan}",
+			)
+			sourceScan, err := utils.Run(cmd)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sourceScan).To(BeEmpty(),
+				"expected status.sourceScan to be absent when scanning is disabled")
+		})
+	})
+
 	Context("Module IaC Scan", Ordered, func() {
 		const (
 			scanVersionName = "terraform-aws-s3-bucket-4-3-0"
@@ -273,6 +342,29 @@ spec:
 			cmd := exec.Command("kubectl", "delete", "version", scanVersionName,
 				"-n", namespace, "--ignore-not-found")
 			_, _ = utils.Run(cmd)
+		})
+
+		BeforeAll(func() {
+			By("upgrading Helm release to enable scanning")
+			chartPath, err := utils.GetChartPath()
+			ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+			// Use the base image ref — the Helm ternary appends "-scanning" automatically
+			// when scanning.enabled=true, so version-controller:e2e-test becomes
+			// version-controller:e2e-test-scanning.
+			baseRepo, baseTag := splitImageRef(projectImage)
+			cmd := exec.Command("helm", "upgrade", helmReleaseName, chartPath,
+				"--reuse-values",
+				"--namespace", namespace,
+				"--set", fmt.Sprintf("version.image.repository=%s", baseRepo),
+				"--set", fmt.Sprintf("version.image.tag=%s", baseTag),
+				"--set", "scanning.enabled=true",
+				"--set", "scanning.cache.accessMode=ReadWriteOnce",
+				"--wait",
+				"--timeout", "3m",
+			)
+			_, err = utils.Run(cmd)
+			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to upgrade Helm release to enable scanning")
 		})
 
 		It("should produce IaC findings for a module with known misconfigurations", func() {

--- a/services/version/test/e2e/e2e_test.go
+++ b/services/version/test/e2e/e2e_test.go
@@ -352,7 +352,7 @@ spec:
 			// Use the base image ref — the Helm ternary appends "-scanning" automatically
 			// when scanning.enabled=true, so version-controller:e2e-test becomes
 			// version-controller:e2e-test-scanning.
-			baseRepo, baseTag := splitImageRef(projectImage)
+			baseRepo, baseTag := utils.SplitImageRef(projectImage)
 			cmd := exec.Command("helm", "upgrade", helmReleaseName, chartPath,
 				"--reuse-values",
 				"--namespace", namespace,


### PR DESCRIPTION
This pull request introduces a two-tier scanning configuration for OpenDepot, separating module IaC scanning from provider binary/source scanning. The Helm chart, CI workflows, and documentation are updated to support this distinction. Now, enabling lightweight module scanning requires only a single flag and no extra infrastructure, while provider scanning (with Trivy DB and CronJob) is opt-in via a separate flag. The version-controller image selection and argument handling are updated accordingly, and documentation is clarified to reflect the new model.

**Helm chart and deployment changes:**

* Added `scanning.providerScanning` flag to distinguish between lightweight module scanning and full provider scanning; PVC and CronJob are now only created when this flag is true (`chart/opendepot/templates/scanning-cronjob.yaml`, `chart/opendepot/templates/scanning-pvc.yaml`, `chart/opendepot/templates/version-deployment.yaml`, `chart/opendepot/values.yaml`) [[1]](diffhunk://#diff-4a663059f5d2d2f9234aa3484e0bf82066c0478d7352d17c2481f4efea74ec83L1-R1) [[2]](diffhunk://#diff-6ca450df594ff1913d55b796caf7b83324505f3f7c546f89915772ca0df86ff2L1-R1) [[3]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L44-R58) [[4]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L72-R87) [[5]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L96-R100) [[6]](diffhunk://#diff-67f8bf52de4a35fbba29da6174c3d281cd28527e26313566b9e83c93938e4d72L162-R184) [[7]](diffhunk://#diff-67f8bf52de4a35fbba29da6174c3d281cd28527e26313566b9e83c93938e4d72L188-R195).
* Version-controller image now automatically uses the `-scanning` variant when `scanning.enabled` is true, and passes the correct arguments and mounts only when `providerScanning` is enabled (`chart/opendepot/templates/version-deployment.yaml`, `chart/opendepot/values.yaml`) [[1]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L44-R58) [[2]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L72-R87) [[3]](diffhunk://#diff-2a344e407f073329f0a5839dc5f8f3a41da5bc1cc918effd81c22c9f765ea4c1L96-R100) [[4]](diffhunk://#diff-67f8bf52de4a35fbba29da6174c3d281cd28527e26313566b9e83c93938e4d72L162-R184).

**CI/CD workflow improvements:**

* Build and e2e workflows updated to build and tag both standard and `-scanning` image variants for version-controller, with appropriate build arguments and matrix entries (`.github/workflows/build.yaml`, `.github/workflows/e2e.yaml`) [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R20-R41) [[2]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L54-R68) [[3]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R85) [[4]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L81-R108) [[5]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R123-R124) [[6]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L115-R147) [[7]](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bR34-R49) [[8]](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bR71) [[9]](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bR323-R326).

**Documentation updates:**

* Scanning documentation rewritten to clarify the two scanning tiers, explain new flags, image selection, and infrastructure requirements (`docs/configuration/scanning.md`) [[1]](diffhunk://#diff-f819ab767f502cb6ce25375de17fe87774ce4cf14012aaabe28448fb7dcd5d2dL13-R16) [[2]](diffhunk://#diff-f819ab767f502cb6ce25375de17fe87774ce4cf14012aaabe28448fb7dcd5d2dL42-R86) [[3]](diffhunk://#diff-f819ab767f502cb6ce25375de17fe87774ce4cf14012aaabe28448fb7dcd5d2dR101) [[4]](diffhunk://#diff-f819ab767f502cb6ce25375de17fe87774ce4cf14012aaabe28448fb7dcd5d2dL94-R130).

**Chart version bump:**

* Helm chart version updated to `0.3.0` to reflect the breaking change in scanning configuration (`chart/opendepot/Chart.yaml`).

**Miscellaneous:**

* Updated planner agent tools to include `search`, `web`, and `vscode/memory` for improved planning capabilities (`.github/agents/planner.agent.md`).