### PR TITLE
Updated gitops docs to focus on an orgs private modules

### DIFF
--- a/docs/guides/gitops.md
+++ b/docs/guides/gitops.md
@@ -24,9 +24,7 @@ This gives you a complete audit trail: every module version published to your re
 ```
 opendepot-manifests/
 ├── modules/
-│   ├── terraform-aws-eks.yaml
-│   ├── terraform-aws-vpc.yaml
-│   └── terraform-azurerm-aks.yaml
+│   └── terraform-aws-eks.yaml
 └── kustomization.yaml
 ```
 
@@ -42,13 +40,13 @@ spec:
   moduleConfig:
     name: terraform-aws-eks
     provider: aws
-    repoOwner: terraform-aws-modules
-    repoUrl: https://github.com/terraform-aws-modules/terraform-aws-eks
+    repoOwner: my-org
+    repoUrl: https://github.com/my-org/terraform-aws-eks
     fileFormat: zip
     immutable: true
     storageConfig:
       s3:
-        bucket: opendepot-modules
+        bucket: my-org-opendepot-modules
         region: us-west-2
     githubClientConfig:
       useAuthenticatedClient: true
@@ -65,7 +63,7 @@ spec:
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: opendepot-modules
+  name: my-org-opendepot-modules
   namespace: argocd
 spec:
   project: default


### PR DESCRIPTION
This pull request updates the `gitops.md` documentation to better reflect a user-specific configuration by customizing example values for organization-specific usage. The main changes focus on updating names and repository references from generic or default values to placeholders representing a custom organization.

**Documentation updates for organization customization:**

* Updated the modules directory example to only include `terraform-aws-eks.yaml`, removing Azure and VPC examples for clarity.
* Changed example `repoOwner`, `repoUrl`, and S3 `bucket` values in the module configuration to use `my-org` instead of the default or upstream values.
* Updated the ArgoCD `Application` resource example to use `my-org-opendepot-modules` as the application name.