### PR TITLE
Update operations.md

### DIFF
--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -195,7 +195,7 @@ kubectl get version terraform-aws-key-pair-2-0-0 -n opendepot-system \
 Provider binary scan results (`Version.status.binaryScan`):
 
 ```bash
-kubectl get version aws-5.81.0-linux-amd64 -n opendepot-system -o jsonpath='{.status.binaryScan}' | jq .
+kubectl get version aws-5-81-0-linux-amd64 -n opendepot-system -o jsonpath='{.status.binaryScan}' | jq .
 ```
 
 Provider source scan results (`Provider.status.sourceScan`):


### PR DESCRIPTION
This pull request updates a documentation example in `docs/guides/operations.md` to correct the format of a provider version identifier in a `kubectl` command.

- **Documentation Fixes:**
  * Updated the example `kubectl` command to use the correct format (`aws-5-81-0-linux-amd64` instead of `aws-5.81.0-linux-amd64`) for the provider version identifier.