### PR TITLE
Added more details around how Dex is used and the difference between the upstream and downstream registration. Added details on using a shared cluster dex instance

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -13,29 +13,11 @@ Configure OpenDepot for your environment. All configuration is done through Helm
 
 <div class="grid cards" markdown>
 
-- :material-kubernetes: &nbsp;[__Namespace-Scoped Mode__](namespace.md)
+- :material-shield-account: &nbsp;[__OIDC Authentication (Dex)__](oidc.md)
 
     ---
 
-    Restrict OpenDepot to a single namespace using `Role` and `RoleBinding` instead of cluster-wide `ClusterRole` resources.
-
-- :material-github: &nbsp;[__GitHub Authentication__](github-auth.md)
-
-    ---
-
-    Configure a GitHub App to authenticate API requests and increase rate limits when using the Depot controller with private repositories.
-
-- :material-lock: &nbsp;[__TLS__](tls.md)
-
-    ---
-
-    Terminate TLS on the OpenDepot server using a Kubernetes Secret, or delegate to an Ingress controller or service mesh.
-
-- :material-key: &nbsp;[__GPG Signing__](gpg.md)
-
-    ---
-
-    Set up GPG signing for provider `SHA256SUMS` files so OpenTofu can cryptographically verify provider archives.
+    Deploy Dex as a bundled OIDC identity provider to enable `tofu login` and single sign-on via Entra ID, Okta, GitHub, LDAP, and other upstream IdPs.
 
 - :material-shield-search: &nbsp;[__Vulnerability Scanning__](scanning.md)
 
@@ -43,10 +25,28 @@ Configure OpenDepot for your environment. All configuration is done through Helm
 
     Enable Trivy-based vulnerability scanning for provider binaries and source dependencies, with optional policy enforcement to block critical or high findings.
 
-- :material-shield-account: &nbsp;[__OIDC Authentication (Dex)__](oidc.md)
+- :material-key: &nbsp;[__GPG Signing__](gpg.md)
 
     ---
 
-    Deploy Dex as a bundled OIDC identity provider to enable `tofu login` and single sign-on via Entra ID, Okta, GitHub, LDAP, and other upstream IdPs.
+    Set up GPG signing for provider `SHA256SUMS` files so OpenTofu can cryptographically verify provider archives.
+
+- :material-github: &nbsp;[__GitHub Authentication__](github-auth.md)
+
+    ---
+
+    Configure a GitHub App to authenticate API requests and increase rate limits when using the Depot controller with private repositories.
+
+- :material-kubernetes: &nbsp;[__Namespace-Scoped Mode__](namespace.md)
+
+    ---
+
+    Restrict OpenDepot to a single namespace using `Role` and `RoleBinding` instead of cluster-wide `ClusterRole` resources.
+
+- :material-lock: &nbsp;[__TLS__](tls.md)
+
+    ---
+
+    Terminate TLS on the OpenDepot server using a Kubernetes Secret, or delegate to an Ingress controller or service mesh.
 
 </div>

--- a/docs/configuration/oidc.md
+++ b/docs/configuration/oidc.md
@@ -22,6 +22,36 @@ When OIDC is enabled the server advertises the `login.v1` block in its service d
 - A publicly reachable hostname for the Dex issuer URL (HTTPS required in production)
 - An upstream IdP OAuth application (GitHub App, Azure App Registration, Okta app, etc.)
 
+## How Authentication Works
+
+Dex acts as a broker between your upstream IdP and OpenDepot. There are two distinct registrations involved, and understanding them avoids the most common configuration mistakes.
+
+**Connector (upstream registration)**
+A connector tells Dex how to authenticate users against an external IdP such as Entra ID, Okta, or GitHub. You create an OAuth application in the IdP (e.g. an Azure App Registration), and configure Dex with the client credentials. The redirect URI on that application points to **Dex's callback URL** — never directly to OpenDepot.
+
+**Static client (downstream registration)**
+A static client registers OpenDepot as an application that *receives tokens from Dex*. The server's `clientId` must match a `staticClient` entry in the Dex config, and the redirect URIs on that client are the `localhost` ports used by `tofu login`.
+
+These two registrations are entirely independent. Swapping or reconfiguring the upstream IdP (connector) does not affect the static client configuration, and vice versa.
+
+```mermaid
+sequenceDiagram
+    participant U as User / tofu login
+    participant OD as OpenDepot Server
+    participant Dex as Dex
+    participant IdP as Upstream IdP
+
+    U->>OD: GET /.well-known/terraform.json
+    OD-->>U: login.v1 (authz URL, client ID)
+    U->>Dex: Authorization request<br/>(staticClient redirect URI)
+    Dex->>IdP: Connector — redirect to IdP login
+    Note right of IdP: App Registration redirect URI<br/>points back to Dex /callback
+    IdP-->>Dex: Authentication callback
+    Dex-->>U: Dex-issued JWT
+    U->>OD: API request with JWT
+    OD->>OD: Validate JWT locally via JWKS
+```
+
 ## Step 1: Enable Dex
 
 Set `dex.enabled: true` and configure the `issuer` and at least one connector in your Helm values. Dex expands `$ENV_VAR` references in its config at startup, so **never write connector secrets as plain string literals** — reference an environment variable instead and expose the value via `dex.envFrom`:
@@ -126,7 +156,7 @@ The `scopes` array tells the OpenTofu CLI which scopes to request during the OID
 
 If `login.v1` is absent, OIDC is not enabled or the server has not restarted after the Helm upgrade.
 
-## Split-Network OIDC (authzUrl / tokenUrl)
+### Split-Network OIDC (authzUrl / tokenUrl)
 
 In some deployments the server must discover Dex via an in-cluster URL (for JWKS fetching and token validation), but the `login.v1` endpoints advertised to CLI clients must be reachable from outside the cluster — for example, through an ingress or a port-forward.
 
@@ -147,6 +177,66 @@ When either value is blank the URL comes from the Dex OIDC discovery document. B
 
 !!! note "Local Kind testing"
     When testing with a local Kind cluster there is no ingress. The `oidc-deploy` Make target sets `authzUrl` and `tokenUrl` to `http://localhost:<dex-port>/dex/auth` and `/token` respectively, so that the browser redirect during `tofu login` reaches the Dex port-forward rather than the unreachable in-cluster address. See [Local OIDC E2E Testing](../contributing.md#local-oidc-e2e-testing) for the contributor workflow.
+
+### Shared / External Dex (Multi-Tenant)
+
+Use this pattern when multiple OpenDepot releases share a cluster and you want a single Dex instance to manage identity for all of them, rather than deploying one Dex pod per registry.
+
+When `server.oidc.issuerUrl` is set explicitly the chart uses it directly — `dex.enabled` controls only whether the bundled Dex subchart is deployed. Set `dex.enabled: false` to skip the subchart entirely and point the server at any OIDC-compliant issuer:
+
+```yaml
+dex:
+  enabled: false  # do not deploy the bundled Dex subchart
+
+server:
+  oidc:
+    enabled: true
+    issuerUrl: "https://dex.example.com/dex"
+    clientId: "opendepot-team-a"  # must match a staticClient id in the shared Dex
+```
+
+!!! note
+    `server.oidc.clientSecret` and `server.oidc.clientSecretName` are ignored when `dex.enabled: false`. The chart creates no Kubernetes Secret and the server binary never reads the client secret — JWT validation uses the issuer's public JWKS endpoint. Client registration in the shared Dex is an out-of-band operator responsibility.
+
+#### Registering Clients in the Shared Dex
+
+Each OpenDepot instance requires its own `staticClient` entry in the shared Dex config. Add a client block for each release, including all redirect URIs that `tofu login` may use:
+
+```yaml
+staticClients:
+  - id: opendepot-team-a
+    name: OpenDepot Team A
+    public: true
+    redirectURIs:
+      - http://localhost:10000/login
+      - http://localhost:10001/login
+      - http://localhost:10002/login
+      - http://localhost:10003/login
+      - http://localhost:10004/login
+      - http://localhost:10005/login
+      - http://localhost:10006/login
+      - http://localhost:10007/login
+      - http://localhost:10008/login
+      - http://localhost:10009/login
+      - http://localhost:10010/login
+  - id: opendepot-team-b
+    name: OpenDepot Team B
+    public: true
+    redirectURIs:
+      - http://localhost:10000/login
+      # ... same redirect URIs as above
+```
+
+#### Client ID Uniqueness
+
+Each OpenDepot release should use a distinct `server.oidc.clientId` registered in the shared Dex. Two releases sharing the same client ID share an OIDC client — access is still scoped per-instance through `GroupBinding`, but there is no Dex-level isolation between the instances. Distinct IDs are strongly recommended.
+
+| Release | Namespace | `server.oidc.clientId` | `server.oidc.issuerUrl` |
+|---------|-----------|------------------------|-------------------------|
+| `opendepot-team-a` | `team-a` | `opendepot-team-a` | `https://dex.example.com/dex` |
+| `opendepot-team-b` | `team-b` | `opendepot-team-b` | `https://dex.example.com/dex` |
+
+If the shared Dex is reachable in-cluster at a different address than external `tofu login` clients need, combine `issuerUrl` with `authzUrl` and `tokenUrl` as described in [Split-Network OIDC](#split-network-oidc-authzurl--tokenurl) above.
 
 ## Step 5: Authenticate with `tofu login`
 


### PR DESCRIPTION
This pull request updates the OpenDepot documentation to clarify and expand configuration guidance for OIDC authentication using Dex, especially in multi-tenant and external Dex scenarios. It also improves the organization and explanations in the configuration index and OIDC documentation, making it easier for users to understand authentication flows and deployment patterns.

**OIDC Authentication and Dex Integration:**

* Added a detailed explanation of how Dex acts as an OIDC broker, clarifying the difference between upstream IdP connectors and downstream static client registrations. Included a Mermaid sequence diagram illustrating the authentication flow between the user, OpenDepot, Dex, and the upstream IdP.
* Added documentation for using a shared or external Dex instance across multiple OpenDepot releases, including configuration examples, client registration requirements, and recommendations for unique client IDs per release.

**Documentation Organization and Clarity:**

* Reorganized the configuration index to highlight OIDC authentication, vulnerability scanning, GPG signing, GitHub authentication, namespace-scoped mode, and TLS setup, improving discoverability and logical grouping of features.
* Clarified the section on split-network OIDC deployments, where internal and external URLs for Dex may differ, and improved section headings for readability.