### PR TITLE
chore: Bumped chart version and removed opendepot header in favor of logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# OpenDepot
-
-[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
-[![Helm](https://img.shields.io/badge/Helm_Chart-0.7.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
-[![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
-
 <p>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/img/opendepot_dark_mode.svg" />
@@ -12,6 +5,11 @@
     <img src="docs/img/opendepot_light_mode.svg" width="400" />
   </picture>
 </p>
+
+[![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
+[![Helm](https://img.shields.io/badge/Helm_Chart-0.8.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
+[![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
 
 A Kubernetes-native, self-hosted OpenTofu/Terraform module and provider registry that implements both the [Module Registry Protocol](https://opentofu.org/docs/internals/module-registry-protocol/) and the [Provider Registry Protocol](https://developer.hashicorp.com/terraform/internals/provider-registry-protocol). OpenDepot gives organizations complete control over distribution, versioning, and storage — without relying on the public registry.
 


### PR DESCRIPTION
This pull request updates the `README.md` file to move the project badges below the logo and updates the Helm chart badge to reflect the new version. These changes improve the visual layout and ensure the documentation reflects the latest release.

Documentation and visual updates:

* Moved the badges for Go version, license, Helm chart, and documentation below the project logo for a cleaner appearance in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-L7) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R9-R13)
* Updated the Helm chart badge to version 0.8.0 to match the latest release.