### PR TITLE
chore: Bump the helm chart version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Go](https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white)](https://go.dev/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tonedefdev/opendepot/blob/main/LICENSE)
-[![Helm](https://img.shields.io/badge/Helm_Chart-0.9.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
+[![Helm](https://img.shields.io/badge/Helm_Chart-0.10.0-0F1689?logo=helm&logoColor=white)](https://github.com/tonedefdev/opendepot/tree/main/chart/opendepot)
 [![Docs](https://img.shields.io/badge/Docs-tonedefdev.github.io-047df1?logo=materialformkdocs&logoColor=white)](https://tonedefdev.github.io/opendepot/)
 
 A Kubernetes-native, self-hosted OpenTofu/Terraform module and provider registry that implements the [Module Registry Protocol](https://opentofu.org/docs/internals/module-registry-protocol/), the [Provider Network Mirror Protocol](https://opentofu.org/docs/internals/provider-network-mirror-protocol/) and the [Provider Registry Protocol](https://opentofu.org/docs/internals/provider-registry-protocol/). OpenDepot gives organizations complete control over distribution, versioning, and storage — without relying on the public registry.


### PR DESCRIPTION
This pull request updates the Helm chart version badge in the `README.md` file to reflect the latest release. No other changes are included.

* Updated the Helm chart version badge from `0.9.0` to `0.10.0` in `README.md` to indicate the new chart release.