### PR TITLE
chore: restore helm footer

### DIFF
--- a/site-root/styles.css
+++ b/site-root/styles.css
@@ -333,13 +333,14 @@
   .footer-helm-icon {
     width: 21px;
     height: 21px;
-    filter: brightness(0) invert(.65);
+    filter: brightness(0) invert(1);
+    opacity: .38;
     object-fit: contain;
-    transition: filter .2s ease;
+    transition: opacity .2s ease;
   }
   .footer-links a:hover .footer-helm-icon,
   .footer-links a:focus-visible .footer-helm-icon {
-    filter: brightness(0) invert(1);
+    opacity: 1;
   }
   @media (max-width: 1100px) {
     main {

--- a/site-root/styles.css
+++ b/site-root/styles.css
@@ -333,15 +333,13 @@
   .footer-helm-icon {
     width: 21px;
     height: 21px;
-    filter: grayscale(1);
-    opacity: .38;
+    filter: brightness(0) invert(.65);
     object-fit: contain;
-    transition: filter .2s ease, opacity .2s ease;
+    transition: filter .2s ease;
   }
   .footer-links a:hover .footer-helm-icon,
   .footer-links a:focus-visible .footer-helm-icon {
     filter: brightness(0) invert(1);
-    opacity: 1;
   }
   @media (max-width: 1100px) {
     main {

--- a/site-root/styles.css
+++ b/site-root/styles.css
@@ -17,6 +17,10 @@
     src: local("Aspekta");
   }
   * { box-sizing: border-box; }
+  .container-xxl {
+    width: min(calc(100% - 48px), 1400px);
+    max-width: none;
+  }
   header[hidden] { display: none !important; }
   html,
   body {
@@ -331,7 +335,25 @@
     height: 21px;
     object-fit: contain;
   }
+  @media (max-width: 1100px) {
+    .row {
+      display: block;
+    }
+    .col-md-5,
+    .col-md-7 {
+      width: 100%;
+    }
+    .hero-copy {
+      transform: none;
+    }
+    .signal {
+      margin-top: 56px;
+    }
+  }
   @media (max-width: 760px) {
+    .container-xxl {
+      width: calc(100% - 40px);
+    }
     header { padding: 20px 0; }
     header img { width: 152px; }
     main {

--- a/site-root/styles.css
+++ b/site-root/styles.css
@@ -333,7 +333,15 @@
   .footer-helm-icon {
     width: 21px;
     height: 21px;
+    filter: grayscale(1);
+    opacity: .38;
     object-fit: contain;
+    transition: filter .2s ease, opacity .2s ease;
+  }
+  .footer-links a:hover .footer-helm-icon,
+  .footer-links a:focus-visible .footer-helm-icon {
+    filter: brightness(0) invert(1);
+    opacity: 1;
   }
   @media (max-width: 1100px) {
     main {

--- a/site-root/styles.css
+++ b/site-root/styles.css
@@ -336,6 +336,9 @@
     object-fit: contain;
   }
   @media (max-width: 1100px) {
+    main {
+      padding-top: 32px;
+    }
     .row {
       display: block;
     }
@@ -347,7 +350,7 @@
       transform: none;
     }
     .signal {
-      margin-top: 56px;
+      margin-top: 40px;
     }
   }
   @media (max-width: 760px) {


### PR DESCRIPTION
## Summary

Restores and polishes the Helm footer link on the OpenDepot marketing page.

## Changes

- Restores the Helm icon in the footer link.
- Applies the intended muted icon treatment in the default state.
- Brightens the icon on hover and keyboard focus.
- Expands the landing-page container on large screens.
- Improves tablet responsiveness by stacking the hero layout below `1100px`.
- Removes excess horizontal spacing on smaller screens.
- Tightens tablet and mobile hero spacing.

## Validation

- Verified the landing page layout at desktop, tablet, and mobile breakpoints.
- Confirmed the Helm footer icon has the expected default, hover, and focus states.
- Confirmed the existing footer link remains functional.