### PR TITLE
chore: correct Pages asset paths

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,12 +47,12 @@ jobs:
         run: |
           cp site-root/index.html site/index.html
           cp site-root/CNAME site/CNAME
-          cp site-root/defdev_logo.svg site/defdev_logo.svg
-          cp site-root/helm_logo.svg site/helm_logo.svg
-          cp site-root/opendepot_icon.svg site/opendepot_icon.svg
-          cp site-root/opendepot_light_mode.svg site/opendepot_light_mode.svg
-          cp site-root/opendepot_white.svg site/opendepot_white.svg
-          cp site-root/registry-*.png site/
+          cp site-root/img/defdev_logo.svg site/defdev_logo.svg
+          cp site-root/img/helm_logo.svg site/helm_logo.svg
+          cp site-root/img/opendepot_icon.svg site/opendepot_icon.svg
+          cp site-root/img/opendepot_light_mode.svg site/opendepot_light_mode.svg
+          cp site-root/img/opendepot_white.svg site/opendepot_white.svg
+          cp site-root/img/registry-*.png site/
 
       - name: Preserve Helm chart index
         run: |


### PR DESCRIPTION
## Summary

Fix the GitHub Pages deployment failure after PR #87 merged.

## Changes

- Copy the marketing-page assets from their actual `site-root/img/` location.
- Preserve the root-relative asset paths expected by `site-root/index.html`.
- Fix the logo and screenshot copies used when assembling the Pages root.

## Validation

- Reproduced the failed asset assembly locally before the fix.
- Verified all logo and screenshot copy commands locally after the fix.
- Workflow YAML validation and `git diff --check` pass.

The previous deployment failed because the workflow attempted to copy `site-root/defdev_logo.svg`, but the file is stored at `site-root/img/defdev_logo.svg`.